### PR TITLE
Allow LLM/Client to pass relative time for the tool calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ var metoroTools = []MetoroTools{
 	},
 	{
 		Name:        "get_logs",
-		Description: "Get logs from all/any services/hosts/pods running in your Kubernetes cluster in the last 5 minutes, monitored by Metoro",
+		Description: "Get logs from all/any services/hosts/pods running in your Kubernetes cluster. Results are limited to 100 logs lines",
 		Handler:     tools.GetLogsHandler,
 	},
 	{

--- a/tools/get_alert_fires.go
+++ b/tools/get_alert_fires.go
@@ -4,18 +4,16 @@ import (
 	"fmt"
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetAlertFiresHandlerArgs struct {
-	AlertId string `json:"alertId" jsonschema:"required,description=The alert ID to get fires for"`
+	TimeConfig utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to get alert fires for. e.g. if you want to get fires for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
+	AlertId    string           `json:"alert_id" jsonschema:"required,description=The ID of the alert to get fires for"`
 }
 
 func GetAlertFiresHandler(arguments GetAlertFiresHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
-
-	body, err := getAlertFiresMetoroCall(arguments.AlertId, fiveMinsAgo.Unix(), now.Unix())
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
+	body, err := getAlertFiresMetoroCall(arguments.AlertId, startTime, endTime)
 	if err != nil {
 		return nil, fmt.Errorf("error getting alert fires: %v", err)
 	}

--- a/tools/get_k8s_event_attribute_values.go
+++ b/tools/get_k8s_event_attribute_values.go
@@ -23,7 +23,8 @@ type GetK8sEventAttributeValueHandlerArgs struct {
 
 func GetK8sEventAttributeValuesForIndividualAttributeHandler(arguments GetK8sEventAttributeValueHandlerArgs) (*mcpgolang.ToolResponse, error) {
 	now := time.Now()
-	sixHoursAgo := now.Add(-6 * time.Hour)
+	// TODO: Figure out the best timerange for this.
+	sixHoursAgo := now.Add(-6 * time.Hour) // Events need to be fetched for the last 6 hours at least as most clusters are very chill.
 	request := model.GetSingleK8sEventSummaryRequest{
 		GetK8sEventsRequest: model.GetK8sEventsRequest{
 			StartTime:      sixHoursAgo.Unix(),

--- a/tools/get_k8s_event_attribute_values.go
+++ b/tools/get_k8s_event_attribute_values.go
@@ -7,10 +7,10 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetK8sEventAttributeValueHandlerArgs struct {
+	TimeConfig     utils.TimeConfig    `json:"time_config" jsonschema:"required,description=The time period to get the possible values of K8 event attributes values. e.g. if you want to see the possible values for the attributes in the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
 	Attribute      string              `json:"attribute" jsonschema:"required,description=The attribute to get values for"`
 	Filters        map[string][]string `json:"filters" jsonschema:"description=The filters to apply to the events. it is a map of filter keys to array values where array values are ORed when the filters are applied.e.g. key for service name is service.name"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=The exclude filters to exclude/eliminate the events. Events matching the exclude filters will not be returned. it is a map of filter keys to array values where array values are ORed when the filters are applied.e.g. key for service name is service.name"`
@@ -22,21 +22,17 @@ type GetK8sEventAttributeValueHandlerArgs struct {
 }
 
 func GetK8sEventAttributeValuesForIndividualAttributeHandler(arguments GetK8sEventAttributeValueHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	// TODO: Figure out the best timerange for this.
-	sixHoursAgo := now.Add(-6 * time.Hour) // Events need to be fetched for the last 6 hours at least as most clusters are very chill.
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetSingleK8sEventSummaryRequest{
 		GetK8sEventsRequest: model.GetK8sEventsRequest{
-			StartTime:      sixHoursAgo.Unix(),
-			EndTime:        now.Unix(),
+			StartTime:      startTime,
+			EndTime:        endTime,
 			Filters:        arguments.Filters,
 			ExcludeFilters: arguments.ExcludeFilters,
 			Regexes:        arguments.Regexes,
 			ExcludeRegexes: arguments.ExcludeRegexes,
 			Environments:   arguments.Environments,
 			Ascending:      arguments.Ascending,
-			// TODO: Deal with the prevend time when you are dealing with the start and endtime.
-			//PrevEndTime: arguments.PrevEndTime,
 		},
 		Attribute: arguments.Attribute,
 	}

--- a/tools/get_k8s_events.go
+++ b/tools/get_k8s_events.go
@@ -7,33 +7,29 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetK8sEventsHandlerArgs struct {
+	TimeConfig     utils.TimeConfig    `json:"time_config" jsonschema:"required,description=The time period to get events for. e.g. if you want to get events for the last 6 hours, you would set time_period=6 and time_window=Hours"`
 	Filters        map[string][]string `json:"filters" jsonschema:"description=Filters to apply to the events"`
-	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=Filters to exclude from the events"`
+	ExcludeFilters map[string][]string `json:"exclude_filters" jsonschema:"description=Filters to exclude from the events"`
 	Regexes        []string            `json:"regexes" jsonschema:"description=Regexes to apply to the event messages"`
-	ExcludeRegexes []string            `json:"excludeRegexes" jsonschema:"description=Regexes to exclude from the event messages"`
-	Environments   []string            `json:"environments" jsonschema:"description=Environments to get events from"`
+	ExcludeRegexes []string            `json:"exclude_regexes" jsonschema:"description=Regexes to exclude from the event messages"`
 	Ascending      bool                `json:"ascending" jsonschema:"description=If true, events will be returned in ascending order, otherwise in descending order"`
-	PrevEndTime    *float64            `json:"prevEndTime" jsonschema:"description=The end time of the previous request"`
+	Environments   []string            `json:"environments" jsonschema:"description=Environments to get events from"`
 }
 
 func GetK8sEventsHandler(arguments GetK8sEventsHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	sixHoursAgo := now.Add(-6 * time.Hour)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetK8sEventsRequest{
-		StartTime:      sixHoursAgo.Unix(),
-		EndTime:        now.Unix(),
+		StartTime:      startTime,
+		EndTime:        endTime,
 		Filters:        arguments.Filters,
 		ExcludeFilters: arguments.ExcludeFilters,
 		Regexes:        arguments.Regexes,
 		ExcludeRegexes: arguments.ExcludeRegexes,
-		Environments:   arguments.Environments,
 		Ascending:      arguments.Ascending,
-		// TODO: Deal with the prevend time when you are dealing with the start and endtime.
-		//PrevEndTime: arguments.PrevEndTime,
+		Environments:   arguments.Environments,
 	}
 
 	jsonBody, err := json.Marshal(request)

--- a/tools/get_k8s_events_volume.go
+++ b/tools/get_k8s_events_volume.go
@@ -7,10 +7,10 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetK8sEventsVolumeHandlerArgs struct {
+	TimeConfig     utils.TimeConfig    `json:"time_config" jsonschema:"required,description=The time period to get events for. e.g. if you want to get events for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
 	Filters        map[string][]string `json:"filters" jsonschema:"description=Filters to apply to the events"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=Filters to exclude from the events"`
 	Regexes        []string            `json:"regexes" jsonschema:"description=Regexes to apply to the event messages"`
@@ -19,11 +19,10 @@ type GetK8sEventsVolumeHandlerArgs struct {
 }
 
 func GetK8sEventsVolumeHandler(arguments GetK8sEventsVolumeHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	sixHoursAgo := now.Add(-6 * time.Hour)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetK8sEventMetricsRequest{
-		StartTime:      sixHoursAgo.Unix(),
-		EndTime:        now.Unix(),
+		StartTime:      startTime,
+		EndTime:        endTime,
 		Filters:        arguments.Filters,
 		ExcludeFilters: arguments.ExcludeFilters,
 		Regexes:        arguments.Regexes,

--- a/tools/get_k8s_service_information.go
+++ b/tools/get_k8s_service_information.go
@@ -7,20 +7,19 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
-type GetK8sSErviceInformationHandlerArgs struct {
-	ServiceName  string   `json:"serviceName" jsonschema:"required,description=The name of the service to get information for"`
-	Environments []string `json:"environments" jsonschema:"description=The environments to get information for. If empty, all environments will be used."`
+type GetK8sServiceInformationHandlerArgs struct {
+	TimeConfig   utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time to get state of the service. e.g. if you want to see the state of the service 5 minutes ago, you would set time_period=5 and time_window=Minutes"`
+	ServiceName  string           `json:"serviceName" jsonschema:"required,description=The name of the service to get information for"`
+	Environments []string         `json:"environments" jsonschema:"description=The environments to get information for. If empty, all environments will be used."`
 }
 
-func GetK8sServiceInformationHandler(arguments GetK8sSErviceInformationHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+func GetK8sServiceInformationHandler(arguments GetK8sServiceInformationHandlerArgs) (*mcpgolang.ToolResponse, error) {
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetPodsRequest{
-		StartTime:    fiveMinsAgo.Unix(),
-		EndTime:      now.Unix(),
+		StartTime:    startTime,
+		EndTime:      endTime,
 		ServiceName:  arguments.ServiceName,
 		Environments: arguments.Environments,
 	}

--- a/tools/get_log_attribute_values.go
+++ b/tools/get_log_attribute_values.go
@@ -7,10 +7,10 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetLogAttributeValuesHandlerArgs struct {
+	TimeConfig     utils.TimeConfig    `json:"time_config" jsonschema:"required,description=The time period to get log attribute values for. e.g. if you want to get values for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
 	Attribute      string              `json:"attribute" jsonschema:"required,description=The attribute to get values for"`
 	Filters        map[string][]string `json:"filters" jsonschema:"description=The filters to apply to the log attribute"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=The filters to exclude from the log attribute"`
@@ -20,12 +20,11 @@ type GetLogAttributeValuesHandlerArgs struct {
 }
 
 func GetLogAttributeValuesForIndividualAttributeHandler(arguments GetLogAttributeValuesHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetSingleLogSummaryRequest{
 		LogSummaryRequest: model.LogSummaryRequest{
-			StartTime:      fiveMinsAgo.Unix(),
-			EndTime:        now.Unix(),
+			StartTime:      startTime,
+			EndTime:        endTime,
 			Filters:        arguments.Filters,
 			ExcludeFilters: arguments.ExcludeFilters,
 			Regexes:        arguments.Regexes,

--- a/tools/get_logs.go
+++ b/tools/get_logs.go
@@ -7,11 +7,10 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
-// TODO: If we figure out how to input start and end times we can directly use GetLogsRequest struct.
 type GetLogsHandlerArgs struct {
+	TimeConfig     utils.TimeConfig    `json:"time_config" jsonschema:"required,description=The time period to get the logs for. e.g. if you want the get the logs for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
 	Filters        map[string][]string `json:"filters" jsonschema:"description=The filters to apply to the logs. it is a map of filter keys to array values where array values are ORed.e.g. key for service name is service.name"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=The filters to exclude from the logs. e.g., '{\"service.name\": [\"/k8s/namespaceX/serviceX\"]}' should exclude logs for serviceX in namespaceX"`
 	Regexes        []string            `json:"regexes" jsonschema:"description=The regexes to apply to the log's messages. Logs with message matching regexes will be returned"`
@@ -21,11 +20,11 @@ type GetLogsHandlerArgs struct {
 }
 
 func GetLogsHandler(arguments GetLogsHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
+
 	request := model.GetLogsRequest{
-		StartTime:      fiveMinsAgo.Unix(),
-		EndTime:        now.Unix(),
+		StartTime:      startTime,
+		EndTime:        endTime,
 		Filters:        arguments.Filters,
 		ExcludeFilters: arguments.ExcludeFilters,
 		Regexes:        arguments.Regexes,

--- a/tools/get_metric.go
+++ b/tools/get_metric.go
@@ -7,10 +7,10 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetMetricHandlerArgs struct {
+	TimeConfig     utils.TimeConfig       `json:"time_config" jsonschema:"required,description=The time period to get the metric/timeseries data for. e.g. if you want to get the timeseries/metric data for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
 	MetricName     string                 `json:"metricName" jsonschema:"required,description=The name of the metric to get"`
 	Aggregation    model.Aggregation      `json:"aggregation" jsonschema:"required,description=The aggregation to apply to the metric. e.g. sum, avg, min, max, count"`
 	Filters        map[string][]string    `json:"filters" jsonschema:"description=Filters to apply to the metric. Metrics matching the filters will be returned"`
@@ -22,11 +22,10 @@ type GetMetricHandlerArgs struct {
 }
 
 func GetMetricHandler(arguments GetMetricHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetMetricRequest{
-		StartTime:      fiveMinsAgo.Unix(),
-		EndTime:        now.Unix(),
+		StartTime:      startTime,
+		EndTime:        endTime,
 		MetricName:     arguments.MetricName,
 		Filters:        arguments.Filters,
 		ExcludeFilters: arguments.ExcludeFilters,

--- a/tools/get_metric_attributes.go
+++ b/tools/get_metric_attributes.go
@@ -7,20 +7,19 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetMetricAttributesHandlerArgs struct {
+	TimeConfig       utils.TimeConfig    `json:"timeConfig" jsonschema:"required,description=The time period to get the possible values of metric attributes"`
 	MetricName       string              `json:"metricName" jsonschema:"required,description=The name of the metric to get attributes for"`
 	FilterAttributes map[string][]string `json:"filterAttributes" jsonschema:"description=The attributes to filter the metric attributes by"`
 }
 
 func GetMetricAttributesHandler(arguments GetMetricAttributesHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.MetricAttributesRequest{
-		StartTime:        fiveMinsAgo.Unix(),
-		EndTime:          now.Unix(),
+		StartTime:        startTime,
+		EndTime:          endTime,
 		MetricName:       arguments.MetricName,
 		FilterAttributes: arguments.FilterAttributes,
 	}

--- a/tools/get_metric_names.go
+++ b/tools/get_metric_names.go
@@ -16,9 +16,9 @@ type GetMetricNamesHandlerArgs struct {
 
 func GetMetricNamesHandler(arguments GetMetricNamesHandlerArgs) (*mcpgolang.ToolResponse, error) {
 	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	hourAgo := now.Add(-1 * time.Hour)
 	request := model.FuzzyMetricsRequest{
-		StartTime:        fiveMinsAgo.Unix(),
+		StartTime:        hourAgo.Unix(),
 		EndTime:          now.Unix(),
 		MetricFuzzyMatch: "", // This will return all the metric names.
 		Environments:     arguments.Environments,

--- a/tools/get_node_info.go
+++ b/tools/get_node_info.go
@@ -13,7 +13,7 @@ type GetNodeInfoHandlerArgs struct {
 
 func GetNodeInfoHandler(arguments GetNodeInfoHandlerArgs) (*mcpgolang.ToolResponse, error) {
 	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	fiveMinsAgo := now.Add(-10 * time.Minute)
 
 	body, err := getNodeInfoMetoroCall(arguments.NodeName, fiveMinsAgo.Unix())
 	if err != nil {

--- a/tools/get_nodes.go
+++ b/tools/get_nodes.go
@@ -7,10 +7,10 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetNodesHandlerArgs struct {
+	TimeConfig     utils.TimeConfig    `json:"time_config" jsonschema:"required,description=The time period to get nodes for. e.g. if you want to get nodes for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
 	Filters        map[string][]string `json:"filters" jsonschema:"description=The filters to apply to the nodes"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=The filters to exclude from the nodes"`
 	Splits         []string            `json:"splits" jsonschema:"description=The splits to apply to the nodes"`
@@ -18,11 +18,10 @@ type GetNodesHandlerArgs struct {
 }
 
 func GetNodesHandler(arguments GetNodesHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetAllNodesRequest{
-		StartTime:      fiveMinsAgo.Unix(),
-		EndTime:        now.Unix(),
+		StartTime:      startTime,
+		EndTime:        endTime,
 		Filters:        arguments.Filters,
 		ExcludeFilters: arguments.ExcludeFilters,
 		Splits:         arguments.Splits,

--- a/tools/get_pods.go
+++ b/tools/get_pods.go
@@ -7,18 +7,17 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetPodsHandlerArgs struct {
-	ServiceName  string   `json:"serviceName" jsonschema:"description=The name of the service to get pods for. One of serviceName or nodeName is required"`
-	NodeName     string   `json:"nodeName" jsonschema:"description=The name of the node to get pods for. One of serviceName or nodeName is required"`
-	Environments []string `json:"environments" jsonschema:"description=The environments to get pods for. If empty, all environments will be used."`
+	TimeConfig   utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to get pods for. e.g. if you want to get pods for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
+	ServiceName  string           `json:"serviceName" jsonschema:"description=The name of the service to get pods for. One of serviceName or nodeName is required"`
+	NodeName     string           `json:"nodeName" jsonschema:"description=The name of the node to get pods for. One of serviceName or nodeName is required"`
+	Environments []string         `json:"environments" jsonschema:"description=The environments to get pods for. If empty, all environments will be used."`
 }
 
 func GetPodsHandler(arguments GetPodsHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 
 	// One of serviceName or nodeName is required.
 	if arguments.ServiceName == "" && arguments.NodeName == "" {
@@ -26,8 +25,8 @@ func GetPodsHandler(arguments GetPodsHandlerArgs) (*mcpgolang.ToolResponse, erro
 	}
 
 	request := model.GetPodsRequest{
-		StartTime:    fiveMinsAgo.Unix(),
-		EndTime:      now.Unix(),
+		StartTime:    startTime,
+		EndTime:      endTime,
 		Environments: arguments.Environments,
 		ServiceName:  arguments.ServiceName,
 		NodeName:     arguments.NodeName,

--- a/tools/get_profiles.go
+++ b/tools/get_profiles.go
@@ -7,20 +7,19 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetProfileHandlerArgs struct {
-	ServiceName    string   `json:"serviceName" jsonschema:"required,description=The name of the service to get profiles for"`
-	ContainerNames []string `json:"containerNames" jsonschema:"description=The container names to get profiles for"`
+	TimeConfig     utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to get profiles for. e.g. if you want to get profiles for the last 5 minutes, you would set time_period=5 and time_window=Minutes."`
+	ServiceName    string           `json:"serviceName" jsonschema:"required,description=The name of the service to get profiles for"`
+	ContainerNames []string         `json:"containerNames" jsonschema:"description=The container names to get profiles for"`
 }
 
 func GetProfilesHandler(arguments GetProfileHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetProfileRequest{
-		StartTime:      fiveMinsAgo.Unix(),
-		EndTime:        now.Unix(),
+		StartTime:      startTime,
+		EndTime:        endTime,
 		ServiceName:    arguments.ServiceName,
 		ContainerNames: arguments.ContainerNames,
 	}

--- a/tools/get_service_summaries.go
+++ b/tools/get_service_summaries.go
@@ -7,20 +7,19 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetServiceSummariesHandlerArgs struct {
-	Namespaces   string   `json:"namespace" jsonschema:"description=The namespace to get service summaries for. If empty, all namespaces will be used."`
-	Environments []string `json:"environments" jsonschema:"description=The environments to get service summaries for. If empty, all environments will be used."`
+	TimeConfig   utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to get service summaries for. e.g. if you want to get summaries for the last 5 minutes, you would set time_period=5 and time_window=Minutes. Try to use a time period 1 hour or less"`
+	Namespaces   string           `json:"namespace" jsonschema:"description=The namespace to get service summaries for. If empty, all namespaces will be used."`
+	Environments []string         `json:"environments" jsonschema:"description=The environments to get service summaries for. If empty, all environments will be used."`
 }
 
 func GetServiceSummariesHandler(arguments GetServiceSummariesHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetServiceSummariesRequest{
-		StartTime:    fiveMinsAgo.Unix(),
-		EndTime:      now.Unix(),
+		StartTime:    startTime,
+		EndTime:      endTime,
 		Namespace:    arguments.Namespaces,
 		Environments: arguments.Environments,
 	}

--- a/tools/get_trace_attribute_values.go
+++ b/tools/get_trace_attribute_values.go
@@ -7,14 +7,12 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetTraceAttributeValuesHandlerArgs struct {
-	// TODO: I don't think we need this field for the LLM tool
-	//TimeConfig   utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to get trace attributes for. e.g. if you want to get attributes for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
-	Attribute    string   `json:"attribute" jsonschema:"required, description=The name of the attribute to get values for"`
-	ServiceNames []string `json:"serviceNames" jsonschema:"description=The service names to get attribute values for"`
+	TimeConfig   utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to use for getting the possible trace attributes values. e.g. if you want to get possible trace attribute for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
+	Attribute    string           `json:"attribute" jsonschema:"required,description=The name of the attribute to get values for"`
+	ServiceNames []string         `json:"serviceNames" jsonschema:"description=The service names to get attribute values for"`
 	//  TODO: I don't think we need these two fields for the LLM tool
 	Filters        map[string][]string `json:"filters" jsonschema:"description=The filters to apply to the traces. it is a map of filter keys to array values where array values are ORed when the filters are applied.e.g. key for service name is service.name"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=The exclude filters to exclude/eliminate the traces. Traces matching the exclude traces will not be returned. it is a map of filter keys to array values where array values are ORed when the filters are applied.e.g. key for service name is service.name"`
@@ -24,12 +22,11 @@ type GetTraceAttributeValuesHandlerArgs struct {
 }
 
 func GetTraceAttributeValuesForIndividualAttributeHandler(arguments GetTraceAttributeValuesHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	hourAgo := now.Add(-1 * time.Hour)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetSingleTraceSummaryRequest{
 		TracesSummaryRequest: model.TracesSummaryRequest{
-			StartTime:      hourAgo.Unix(),
-			EndTime:        now.Unix(),
+			StartTime:      startTime,
+			EndTime:        endTime,
 			Filters:        arguments.Filters,
 			ExcludeFilters: arguments.ExcludeFilters,
 			Regexes:        arguments.Regexes,

--- a/tools/get_trace_attribute_values.go
+++ b/tools/get_trace_attribute_values.go
@@ -11,8 +11,9 @@ import (
 )
 
 type GetTraceAttributeValuesHandlerArgs struct {
-	Attribute    string   `json:"attribute" jsonschema:"required, description=The name of the attribute to get values for"`
-	ServiceNames []string `json:"serviceNames" jsonschema:"description=The service names to get attribute values for"`
+	TimeConfig   utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to get trace attributes for. e.g. if you want to get attributes for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
+	Attribute    string           `json:"attribute" jsonschema:"required, description=The name of the attribute to get values for"`
+	ServiceNames []string         `json:"serviceNames" jsonschema:"description=The service names to get attribute values for"`
 	//  TODO: I don't think we need these two fields for the LLM tool
 	Filters        map[string][]string `json:"filters" jsonschema:"description=The filters to apply to the traces. it is a map of filter keys to array values where array values are ORed when the filters are applied.e.g. key for service name is service.name"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=The exclude filters to exclude/eliminate the traces. Traces matching the exclude traces will not be returned. it is a map of filter keys to array values where array values are ORed when the filters are applied.e.g. key for service name is service.name"`
@@ -23,12 +24,11 @@ type GetTraceAttributeValuesHandlerArgs struct {
 
 func GetTraceAttributeValuesForIndividualAttributeHandler(arguments GetTraceAttributeValuesHandlerArgs) (*mcpgolang.ToolResponse, error) {
 	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	hourAgo := now.Add(-1 * time.Hour)
 	request := model.GetSingleTraceSummaryRequest{
 		TracesSummaryRequest: model.TracesSummaryRequest{
-			StartTime:      fiveMinsAgo.Unix(),
+			StartTime:      hourAgo.Unix(),
 			EndTime:        now.Unix(),
-			ServiceNames:   arguments.ServiceNames,
 			Filters:        arguments.Filters,
 			ExcludeFilters: arguments.ExcludeFilters,
 			Regexes:        arguments.Regexes,

--- a/tools/get_trace_attribute_values.go
+++ b/tools/get_trace_attribute_values.go
@@ -11,9 +11,10 @@ import (
 )
 
 type GetTraceAttributeValuesHandlerArgs struct {
-	TimeConfig   utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to get trace attributes for. e.g. if you want to get attributes for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
-	Attribute    string           `json:"attribute" jsonschema:"required, description=The name of the attribute to get values for"`
-	ServiceNames []string         `json:"serviceNames" jsonschema:"description=The service names to get attribute values for"`
+	// TODO: I don't think we need this field for the LLM tool
+	//TimeConfig   utils.TimeConfig `json:"time_config" jsonschema:"required,description=The time period to get trace attributes for. e.g. if you want to get attributes for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
+	Attribute    string   `json:"attribute" jsonschema:"required, description=The name of the attribute to get values for"`
+	ServiceNames []string `json:"serviceNames" jsonschema:"description=The service names to get attribute values for"`
 	//  TODO: I don't think we need these two fields for the LLM tool
 	Filters        map[string][]string `json:"filters" jsonschema:"description=The filters to apply to the traces. it is a map of filter keys to array values where array values are ORed when the filters are applied.e.g. key for service name is service.name"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=The exclude filters to exclude/eliminate the traces. Traces matching the exclude traces will not be returned. it is a map of filter keys to array values where array values are ORed when the filters are applied.e.g. key for service name is service.name"`

--- a/tools/get_trace_metric.go
+++ b/tools/get_trace_metric.go
@@ -7,10 +7,10 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetTraceMetricHandlerArgs struct {
+	TimeConfig     utils.TimeConfig       `json:"time_config" jsonschema:"required,description=The time period to get traces for. e.g. if you want to get traces for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
 	ServiceNames   []string               `json:"serviceNames" jsonschema:"description=Service names to return traces for"`
 	Filters        map[string][]string    `json:"filters" jsonschema:"description=The filters to apply to the traces. it is a map of filter keys to array values where array values are ORed.e.g. key for service name is service.name"`
 	ExcludeFilters map[string][]string    `json:"excludeFilters" jsonschema:"description=The exclude filters to exclude/eliminate the traces. Traces matching the exclude traces will not be returned. it is a map of filter keys to array values where array values are ORed.e.g. key for service name is service.name"`
@@ -23,11 +23,10 @@ type GetTraceMetricHandlerArgs struct {
 }
 
 func GetTraceMetricHandler(arguments GetTraceMetricHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetTraceMetricRequest{
-		StartTime:      fiveMinsAgo.Unix(),
-		EndTime:        now.Unix(),
+		StartTime:      startTime,
+		EndTime:        endTime,
 		ServiceNames:   arguments.ServiceNames,
 		Filters:        arguments.Filters,
 		ExcludeFilters: arguments.ExcludeFilters,

--- a/tools/get_traces.go
+++ b/tools/get_traces.go
@@ -7,10 +7,10 @@ import (
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 	"github.com/metoro-io/metoro-mcp-server/utils"
-	"time"
 )
 
 type GetTracesHandlerArgs struct {
+	TimeConfig     utils.TimeConfig    `json:"time_config" jsonschema:"required,description=The time period to get traces for. e.g. if you want to get traces for the last 5 minutes, you would set time_period=5 and time_window=Minutes"`
 	ServiceNames   []string            `json:"serviceNames" jsonschema:"description=Service names to return traces for"`
 	Filters        map[string][]string `json:"filters" jsonschema:"description=The filters to apply to the traces. it is a map of filter keys to array values where array values are ORed.e.g. key for service name is service.name"`
 	ExcludeFilters map[string][]string `json:"excludeFilters" jsonschema:"description=The exclude filters to exclude/eliminate the traces. Traces matching the exclude traces will not be returned. it is a map of filter keys to array values where array values are ORed.e.g. key for service name is service.name"`
@@ -21,11 +21,10 @@ type GetTracesHandlerArgs struct {
 }
 
 func GetTracesHandler(arguments GetTracesHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	now := time.Now()
-	fiveMinsAgo := now.Add(-5 * time.Minute)
+	startTime, endTime := utils.CalculateTimeRange(arguments.TimeConfig)
 	request := model.GetTracesRequest{
-		StartTime:      fiveMinsAgo.Unix(),
-		EndTime:        now.Unix(),
+		StartTime:      startTime,
+		EndTime:        endTime,
 		ServiceNames:   arguments.ServiceNames,
 		Filters:        arguments.Filters,
 		ExcludeFilters: arguments.ExcludeFilters,

--- a/utils/time_utils.go
+++ b/utils/time_utils.go
@@ -1,0 +1,39 @@
+package utils
+
+import "time"
+
+// TimeWindow represents supported time window units
+type TimeWindow string
+
+const (
+	Minutes TimeWindow = "Minutes"
+	Hours   TimeWindow = "Hours"
+	Days    TimeWindow = "Days"
+)
+
+// TimeConfig holds the configuration for time range calculation
+type TimeConfig struct {
+	TimePeriod int        `json:"time_period" jsonschema:"required,description=The time period"`
+	TimeWindow TimeWindow `json:"time_window" jsonschema:"required,description=The time window, e.g., Minutes, Hours, Days"`
+}
+
+// calculateTimeRange returns start and end timestamps based on the time configuration
+func CalculateTimeRange(config TimeConfig) (startTime, endTime int64) {
+	now := time.Now()
+	var duration time.Duration
+
+	switch config.TimeWindow {
+	case Minutes:
+		duration = time.Duration(config.TimePeriod) * time.Minute
+	case Hours:
+		duration = time.Duration(config.TimePeriod) * time.Hour
+	case Days:
+		duration = time.Duration(config.TimePeriod) * 24 * time.Hour
+	default:
+		// Default to minutes if unspecified
+		duration = time.Duration(config.TimePeriod) * time.Minute
+	}
+
+	startTimeObj := now.Add(-duration)
+	return startTimeObj.Unix(), now.Unix()
+}

--- a/utils/time_utils.go
+++ b/utils/time_utils.go
@@ -1,6 +1,9 @@
 package utils
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // TimeWindow represents supported time window units
 type TimeWindow string
@@ -22,15 +25,18 @@ func CalculateTimeRange(config TimeConfig) (startTime, endTime int64) {
 	now := time.Now()
 	var duration time.Duration
 
-	switch config.TimeWindow {
-	case Minutes:
+	// Convert to lowercase for case-insensitive comparison
+	window := strings.ToLower(string(config.TimeWindow))
+
+	switch window {
+	case "minutes", "minute", "min", "mins":
 		duration = time.Duration(config.TimePeriod) * time.Minute
-	case Hours:
+	case "hours", "hour", "hr", "hrs":
 		duration = time.Duration(config.TimePeriod) * time.Hour
-	case Days:
+	case "days", "day":
 		duration = time.Duration(config.TimePeriod) * 24 * time.Hour
 	default:
-		// Default to minutes if unspecified
+		// Default to minutes if unspecified or invalid
 		duration = time.Duration(config.TimePeriod) * time.Minute
 	}
 

--- a/utils/time_utils_test.go
+++ b/utils/time_utils_test.go
@@ -1,0 +1,168 @@
+package utils
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCalculateTimeRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     TimeConfig
+		wantPeriod time.Duration // Expected time difference between start and end
+	}{
+		// Basic functionality tests
+		{
+			name: "5 minutes",
+			config: TimeConfig{
+				TimePeriod: 5,
+				TimeWindow: "Minutes",
+			},
+			wantPeriod: 5 * time.Minute,
+		},
+		{
+			name: "2 hours",
+			config: TimeConfig{
+				TimePeriod: 2,
+				TimeWindow: "Hours",
+			},
+			wantPeriod: 2 * time.Hour,
+		},
+		{
+			name: "3 days",
+			config: TimeConfig{
+				TimePeriod: 3,
+				TimeWindow: "Days",
+			},
+			wantPeriod: 3 * 24 * time.Hour,
+		},
+		// Case sensitivity tests for Minutes
+		{
+			name: "minutes lowercase",
+			config: TimeConfig{
+				TimePeriod: 5,
+				TimeWindow: "minutes",
+			},
+			wantPeriod: 5 * time.Minute,
+		},
+		{
+			name: "minutes uppercase",
+			config: TimeConfig{
+				TimePeriod: 5,
+				TimeWindow: "MINUTES",
+			},
+			wantPeriod: 5 * time.Minute,
+		},
+		{
+			name: "minute singular",
+			config: TimeConfig{
+				TimePeriod: 1,
+				TimeWindow: "minute",
+			},
+			wantPeriod: 1 * time.Minute,
+		},
+		{
+			name: "mins abbreviation",
+			config: TimeConfig{
+				TimePeriod: 5,
+				TimeWindow: "mins",
+			},
+			wantPeriod: 5 * time.Minute,
+		},
+		// Case sensitivity tests for Hours
+		{
+			name: "hours lowercase",
+			config: TimeConfig{
+				TimePeriod: 2,
+				TimeWindow: "hours",
+			},
+			wantPeriod: 2 * time.Hour,
+		},
+		{
+			name: "hours uppercase",
+			config: TimeConfig{
+				TimePeriod: 2,
+				TimeWindow: "HOURS",
+			},
+			wantPeriod: 2 * time.Hour,
+		},
+		{
+			name: "hour singular",
+			config: TimeConfig{
+				TimePeriod: 1,
+				TimeWindow: "hour",
+			},
+			wantPeriod: 1 * time.Hour,
+		},
+		{
+			name: "hrs abbreviation",
+			config: TimeConfig{
+				TimePeriod: 2,
+				TimeWindow: "hrs",
+			},
+			wantPeriod: 2 * time.Hour,
+		},
+		// Case sensitivity tests for Days
+		{
+			name: "days lowercase",
+			config: TimeConfig{
+				TimePeriod: 3,
+				TimeWindow: "days",
+			},
+			wantPeriod: 3 * 24 * time.Hour,
+		},
+		{
+			name: "days uppercase",
+			config: TimeConfig{
+				TimePeriod: 3,
+				TimeWindow: "DAYS",
+			},
+			wantPeriod: 3 * 24 * time.Hour,
+		},
+		{
+			name: "day singular",
+			config: TimeConfig{
+				TimePeriod: 1,
+				TimeWindow: "day",
+			},
+			wantPeriod: 1 * 24 * time.Hour,
+		},
+		{
+			name: "default to minutes when window unspecified",
+			config: TimeConfig{
+				TimePeriod: 10,
+				TimeWindow: "InvalidWindow",
+			},
+			wantPeriod: 10 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			startTime, endTime := CalculateTimeRange(tt.config)
+			
+			// Convert Unix timestamps back to time.Time for easier comparison
+			startTimeObj := time.Unix(startTime, 0)
+			endTimeObj := time.Unix(endTime, 0)
+
+			// Check if the time difference matches expected duration
+			gotPeriod := endTimeObj.Sub(startTimeObj)
+			if gotPeriod != tt.wantPeriod {
+				t.Errorf("CalculateTimeRange() time period = %v, want %v", gotPeriod, tt.wantPeriod)
+			}
+
+			// Check if endTime is approximately now (within 1 second tolerance)
+			nowUnix := time.Now().Unix()
+			if diff := abs(endTime - nowUnix); diff > 1 {
+				t.Errorf("CalculateTimeRange() endTime is not close enough to current time. diff = %v seconds", diff)
+			}
+		})
+	}
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}


### PR DESCRIPTION
This PR introduces a reusable relative time range (5/10 mins/hours ago) calculation functionality to replace hardcoded time durations across handlers. Key changes include:

- Add TimeConfig struct with TimePeriod and TimeWindow fields
- Implement CalculateTimeRange utility function with support for Minutes, Hours, and Days
- Add tests for CalculateTimeRange. 

The changes allow clients to specify custom time ranges when making API calls instead of using hardcoded durations, making the handlers more flexible and reusable.

---
TODOs: 
- Allow ability to pass custom start and end times. 
