### PR TITLE
Only apply metric validation for actual metrics

### DIFF
--- a/tools/get_multi_metric.go
+++ b/tools/get_multi_metric.go
@@ -190,6 +190,9 @@ func CheckAttributes(ctx context.Context, requestType model.MetricType, filters 
 
 func checkTimeseries(ctx context.Context, timeseries []SingleMetricRequest, startTime, endTime int64) error {
 	for _, ts := range timeseries {
+		if ts.Type != model.Metric {
+			continue
+		}
 		err := CheckMetric(ctx, ts.MetricName)
 		if err != nil {
 			return err


### PR DESCRIPTION
Log / trace metrics arent subject to the same checks that actual metrics are. They have dynamic key value pairs. This currently stops the agent from making good timeseries calls for logs + traces.