### PR TITLE
Add anomaly investigation structured output to MCP tools

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -608,6 +608,41 @@ type DeploymentVerificationStructuredOutput struct {
 	Checks        []DeploymentVerificationCheck `json:"checks,omitempty" jsonschema:"description=Structured checks used to evaluate deployment health"`
 }
 
+type AnomalyInvestigationEvidence struct {
+	ToolCallID string `json:"toolCallId,omitempty" jsonschema:"description=Tool call ID supporting this anomaly investigation evidence"`
+	Reasoning  string `json:"reasoning,omitempty" jsonschema:"description=Reasoning from the tool output supporting this anomaly investigation evidence"`
+}
+
+type AnomalyInvestigationSignalDetail struct {
+	ID            string   `json:"id,omitempty" jsonschema:"description=Stable identifier for the observed anomaly signal"`
+	Summary       string   `json:"summary,omitempty" jsonschema:"description=Brief summary of the signal and why it matters"`
+	CurrentValue  *float64 `json:"currentValue,omitempty" jsonschema:"description=Current observed value for the signal"`
+	BaselineValue *float64 `json:"baselineValue,omitempty" jsonschema:"description=Baseline or expected value for comparison"`
+	Unit          string   `json:"unit,omitempty" jsonschema:"description=Unit for the observed numeric values"`
+	Count         *int64   `json:"count,omitempty" jsonschema:"description=Optional count associated with the anomaly signal"`
+}
+
+type AnomalyInvestigationRootCauseLink struct {
+	Title       string                         `json:"title,omitempty" jsonschema:"description=Short title for a root cause link in the causal chain"`
+	Summary     string                         `json:"summary,omitempty" jsonschema:"description=Brief explanation of how this root cause link contributes to the anomaly"`
+	ServiceName string                         `json:"serviceName,omitempty" jsonschema:"description=Service associated with this root cause link"`
+	Evidence    []AnomalyInvestigationEvidence `json:"evidence,omitempty" jsonschema:"description=Evidence supporting this root cause link"`
+}
+
+type AnomalyInvestigationEvidenceSection struct {
+	Title    string                         `json:"title,omitempty" jsonschema:"description=Title for a supporting evidence section"`
+	Summary  string                         `json:"summary,omitempty" jsonschema:"description=Brief explanation of the supporting evidence"`
+	Evidence []AnomalyInvestigationEvidence `json:"evidence,omitempty" jsonschema:"description=Evidence entries included in this section"`
+}
+
+type AnomalyInvestigationStructuredOutput struct {
+	SignalSummary      string                                `json:"signalSummary,omitempty" jsonschema:"description=Summary of the primary anomaly signal that triggered the investigation"`
+	SignalDetails      []AnomalyInvestigationSignalDetail    `json:"signalDetails,omitempty" jsonschema:"description=Structured details about the observed anomaly signals"`
+	RootCauseChain     []AnomalyInvestigationRootCauseLink   `json:"rootCauseChain,omitempty" jsonschema:"description=Ordered chain describing the likely root causes of the anomaly"`
+	SupportingEvidence []AnomalyInvestigationEvidenceSection `json:"supportingEvidence,omitempty" jsonschema:"description=Additional evidence sections that support the investigation findings"`
+	ImpactSummary      string                                `json:"impactSummary,omitempty" jsonschema:"description=Brief summary of the customer or system impact caused by the anomaly"`
+}
+
 type CreateInvestigationRequest struct {
 	Title                                  string                                  `json:"title" binding:"required"`
 	Category                               string                                  `json:"category"`
@@ -615,6 +650,7 @@ type CreateInvestigationRequest struct {
 	RecommendedActions                     *[]string                               `json:"recommendedActions,omitempty"`
 	Markdown                               string                                  `json:"markdown" binding:"required"`
 	DeploymentVerificationStructuredOutput *DeploymentVerificationStructuredOutput `json:"deploymentVerificationStructuredOutput,omitempty"`
+	AnomalyInvestigationStructuredOutput   *AnomalyInvestigationStructuredOutput   `json:"anomalyInvestigationStructuredOutput,omitempty"`
 	Tags                                   map[string]string                       `json:"tags,omitempty"`
 	IssueStartTime                         *time.Time                              `json:"issueStartTime,omitempty"`
 	IssueEndTime                           *time.Time                              `json:"issueEndTime,omitempty"`
@@ -639,6 +675,7 @@ type UpdateInvestigationRequest struct {
 	Summary                                *string                                 `json:"summary,omitempty"`
 	Markdown                               *string                                 `json:"markdown,omitempty"`
 	DeploymentVerificationStructuredOutput *DeploymentVerificationStructuredOutput `json:"deploymentVerificationStructuredOutput,omitempty"`
+	AnomalyInvestigationStructuredOutput   *AnomalyInvestigationStructuredOutput   `json:"anomalyInvestigationStructuredOutput,omitempty"`
 	Tags                                   *map[string]string                      `json:"tags,omitempty"`
 	IssueStartTime                         *time.Time                              `json:"issueStartTime,omitempty"`
 	IssueEndTime                           *time.Time                              `json:"issueEndTime,omitempty"`

--- a/tools/create_investigation.go
+++ b/tools/create_investigation.go
@@ -32,8 +32,9 @@ type CreateInvestigationHandlerArgs struct {
 	ServiceName                            *string                                       `json:"serviceName,omitempty" jsonschema:"description=Optional root cause service name to associate with this investigation."`
 	Environment                            *string                                       `json:"environment,omitempty" jsonschema:"description=Optional environment to associate with this investigation (e.g. production or staging)."`
 	Namespace                              *string                                       `json:"namespace,omitempty" jsonschema:"description=Optional Kubernetes namespace to associate with this investigation."`
-	Markdown                               string                                        `json:"markdown" jsonschema:"required,description=Markdown content for the human-readable investigation narrative. Put structured deployment verification results in deploymentVerificationStructuredOutput instead of encoding them in markdown."`
+	Markdown                               string                                        `json:"markdown" jsonschema:"required,description=Markdown content for the human-readable investigation narrative. Put structured deployment verification results in deploymentVerificationStructuredOutput and structured anomaly page data in anomalyInvestigationStructuredOutput instead of encoding them in markdown."`
 	DeploymentVerificationStructuredOutput *model.DeploymentVerificationStructuredOutput `json:"deploymentVerificationStructuredOutput,omitempty" jsonschema:"description=Optional structured deployment verification output. Populate this field directly for machine-readable deployment checks instead of encoding structured output inside markdown."`
+	AnomalyInvestigationStructuredOutput   *model.AnomalyInvestigationStructuredOutput   `json:"anomalyInvestigationStructuredOutput,omitempty" jsonschema:"description=Optional structured anomaly investigation output. Populate this field directly for machine-readable anomaly page data instead of encoding structured output inside markdown."`
 	InProgress                             *bool                                         `json:"inProgress" jsonschema:"description=Whether the investigation is in progress or not. Defaults to false"`
 	TimeConfig                             utils.TimeConfig                              `json:"time_config" jsonschema:"required,description=The time period to get the pods for. e.g. if you want the get the pods for the last 5 minutes you would set time_period=5 and time_window=Minutes. You can also set an absolute time range by setting start_time and end_time"`
 	ChatHistoryUUID                        *string                                       `json:"chatHistoryUuid,omitempty" jsonschema:"description=Optional chat history UUID to associate with this investigation"`
@@ -102,6 +103,7 @@ func CreateInvestigationHandler(ctx context.Context, arguments CreateInvestigati
 		RecommendedActions:                     arguments.RecommendedActions,
 		Markdown:                               arguments.Markdown,
 		DeploymentVerificationStructuredOutput: arguments.DeploymentVerificationStructuredOutput,
+		AnomalyInvestigationStructuredOutput:   arguments.AnomalyInvestigationStructuredOutput,
 		Tags:                                   tags,
 		IssueStartTime:                         &start,
 		IssueEndTime:                           &end,

--- a/tools/create_investigation_test.go
+++ b/tools/create_investigation_test.go
@@ -222,6 +222,60 @@ func TestCreateInvestigationHandlerForwardsDeploymentVerificationStructuredOutpu
 	}
 }
 
+func TestCreateInvestigationHandlerForwardsAnomalyInvestigationStructuredOutput(t *testing.T) {
+	var mu sync.Mutex
+	var captured *model.CreateInvestigationRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST method, got %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/investigation" {
+			t.Fatalf("expected path /api/v1/investigation, got %s", r.URL.Path)
+		}
+
+		var req model.CreateInvestigationRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+
+		mu.Lock()
+		capturedReq := req
+		captured = &capturedReq
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"uuid":"new-investigation"}`))
+	}))
+	defer server.Close()
+
+	setMetoroAPIEnv(t, server.URL)
+
+	structuredOutput := anomalyInvestigationStructuredOutputFixture()
+
+	_, err := CreateInvestigationHandler(context.Background(), CreateInvestigationHandlerArgs{
+		Title:                                "title",
+		Category:                             investigationCategoryAnomalyInvestigation,
+		Summary:                              "summary",
+		Markdown:                             "markdown",
+		AnomalyInvestigationStructuredOutput: structuredOutput,
+		TimeConfig:                           investigationAbsoluteTimeConfig(),
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if captured == nil {
+		t.Fatalf("expected request to be captured")
+	}
+	if !reflect.DeepEqual(captured.AnomalyInvestigationStructuredOutput, structuredOutput) {
+		t.Fatalf("expected structured output to be forwarded unchanged, got %#v", captured.AnomalyInvestigationStructuredOutput)
+	}
+}
+
 func TestCreateInvestigationHandlerAddsEnvironmentAndNamespaceTags(t *testing.T) {
 	environment := "production"
 	namespace := "payments"
@@ -322,5 +376,51 @@ func investigationStructuredOutputFixture() *model.DeploymentVerificationStructu
 				Summary: "Error rate regressed after deployment",
 			},
 		},
+	}
+}
+
+func anomalyInvestigationStructuredOutputFixture() *model.AnomalyInvestigationStructuredOutput {
+	currentValue := 0.18
+	baselineValue := 0.02
+	count := int64(42)
+
+	return &model.AnomalyInvestigationStructuredOutput{
+		SignalSummary: "Elevated checkout 5XX rate after deploy",
+		SignalDetails: []model.AnomalyInvestigationSignalDetail{
+			{
+				ID:            "trace_5xx",
+				Summary:       "Checkout 5XX rate spiked above baseline",
+				CurrentValue:  &currentValue,
+				BaselineValue: &baselineValue,
+				Unit:          "percent",
+				Count:         &count,
+			},
+		},
+		RootCauseChain: []model.AnomalyInvestigationRootCauseLink{
+			{
+				Title:       "Checkout API timed out on payment dependency",
+				Summary:     "Timeouts in the payment dependency propagated into checkout failures",
+				ServiceName: "checkout-api",
+				Evidence: []model.AnomalyInvestigationEvidence{
+					{
+						ToolCallID: "call_trace_1",
+						Reasoning:  "Trace waterfall shows payment dependency timeouts before request failures",
+					},
+				},
+			},
+		},
+		SupportingEvidence: []model.AnomalyInvestigationEvidenceSection{
+			{
+				Title:   "Logs",
+				Summary: "Error logs increased during the anomaly window",
+				Evidence: []model.AnomalyInvestigationEvidence{
+					{
+						ToolCallID: "call_logs_1",
+						Reasoning:  "Production logs show payment timeout errors clustered with the spike",
+					},
+				},
+			},
+		},
+		ImpactSummary: "Checkout requests failed for 14 minutes.",
 	}
 }

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -215,12 +215,12 @@ And then you can call this tool (get_k8s_events) to get the specific events you 
 	},
 	{
 		Name:        "create_investigation",
-		Description: "Create a new investigation to document and track an issue or incident. Category is required and must be one of deployment_verification, anomaly_investigation, or alert_investigation. Verdict is optional on create (pending, healthy, degraded, or failed). Put structured deployment verification data in deploymentVerificationStructuredOutput directly rather than encoding structured output inside markdown.",
+		Description: "Create a new investigation to document and track an issue or incident. Category is required and must be one of deployment_verification, anomaly_investigation, or alert_investigation. Verdict is optional on create (pending, healthy, degraded, or failed). Put structured deployment verification data in deploymentVerificationStructuredOutput and structured anomaly page data in anomalyInvestigationStructuredOutput directly rather than encoding structured output inside markdown.",
 		Handler:     CreateInvestigationHandler,
 	},
 	{
 		Name:        "update_investigation",
-		Description: "Update an existing investigation by its UUID. Allows updating the title, markdown content, time range, verdict, and other properties. Put structured deployment verification data in deploymentVerificationStructuredOutput directly rather than encoding structured output inside markdown. When closing a deployment_verification investigation (inProgress=false), a final verdict is required and must be healthy, degraded, or failed.",
+		Description: "Update an existing investigation by its UUID. Allows updating the title, markdown content, time range, verdict, and other properties. Put structured deployment verification data in deploymentVerificationStructuredOutput and structured anomaly page data in anomalyInvestigationStructuredOutput directly rather than encoding structured output inside markdown. When closing a deployment_verification investigation (inProgress=false), a final verdict is required and must be healthy, degraded, or failed.",
 		Handler:     UpdateInvestigationHandler,
 	},
 	{

--- a/tools/update_investigation.go
+++ b/tools/update_investigation.go
@@ -21,8 +21,9 @@ type UpdateInvestigationHandlerArgs struct {
 	ServiceName                            *string                                       `json:"serviceName,omitempty" jsonschema:"description=Optional root cause service name to associate with this investigation."`
 	Environment                            *string                                       `json:"environment,omitempty" jsonschema:"description=Optional environment to associate with this investigation (e.g. production or staging)."`
 	Namespace                              *string                                       `json:"namespace,omitempty" jsonschema:"description=Optional Kubernetes namespace to associate with this investigation."`
-	Markdown                               string                                        `json:"markdown" jsonschema:"required,description=Markdown content for the human-readable investigation narrative. Put structured deployment verification results in deploymentVerificationStructuredOutput instead of encoding them in markdown."`
+	Markdown                               string                                        `json:"markdown" jsonschema:"required,description=Markdown content for the human-readable investigation narrative. Put structured deployment verification results in deploymentVerificationStructuredOutput and structured anomaly page data in anomalyInvestigationStructuredOutput instead of encoding them in markdown."`
 	DeploymentVerificationStructuredOutput *model.DeploymentVerificationStructuredOutput `json:"deploymentVerificationStructuredOutput,omitempty" jsonschema:"description=Optional structured deployment verification output. Populate this field directly for machine-readable deployment checks instead of encoding structured output inside markdown."`
+	AnomalyInvestigationStructuredOutput   *model.AnomalyInvestigationStructuredOutput   `json:"anomalyInvestigationStructuredOutput,omitempty" jsonschema:"description=Optional structured anomaly investigation output. Populate this field directly for machine-readable anomaly page data instead of encoding structured output inside markdown."`
 	InProgress                             *bool                                         `json:"inProgress" jsonschema:"description=Whether the investigation is in progress or not. Defaults to false"`
 	TimeConfig                             utils.TimeConfig                              `json:"time_config" jsonschema:"required,description=The time period to get the pods for. e.g. if you want the get the pods for the last 5 minutes you would set time_period=5 and time_window=Minutes. You can also set an absolute time range by setting start_time and end_time"`
 	ChatHistoryUUID                        *string                                       `json:"chatHistoryUuid,omitempty" jsonschema:"description=Optional chat history UUID to associate with this investigation"`
@@ -114,6 +115,7 @@ func UpdateInvestigationHandler(ctx context.Context, arguments UpdateInvestigati
 		Summary:                                &summary,
 		Markdown:                               &markdown,
 		DeploymentVerificationStructuredOutput: arguments.DeploymentVerificationStructuredOutput,
+		AnomalyInvestigationStructuredOutput:   arguments.AnomalyInvestigationStructuredOutput,
 		IssueStartTime:                         &start,
 		IssueEndTime:                           &end,
 		ChatHistoryUUID:                        arguments.ChatHistoryUUID,

--- a/tools/update_investigation_test.go
+++ b/tools/update_investigation_test.go
@@ -215,6 +215,64 @@ func TestUpdateInvestigationHandlerForwardsDeploymentVerificationStructuredOutpu
 	}
 }
 
+func TestUpdateInvestigationHandlerForwardsAnomalyInvestigationStructuredOutput(t *testing.T) {
+	var mu sync.Mutex
+	putCalled := false
+	var captured *model.UpdateInvestigationRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/investigation" {
+			t.Fatalf("expected path /api/v1/investigation, got %s", r.URL.Path)
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Query().Get("uuid") != "inv-uuid" {
+				t.Fatalf("expected uuid query param inv-uuid, got %s", r.URL.Query().Get("uuid"))
+			}
+			_, _ = w.Write([]byte(`{"category":"anomaly_investigation"}`))
+		case http.MethodPut:
+			var req model.UpdateInvestigationRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("failed to decode request body: %v", err)
+			}
+			mu.Lock()
+			putCalled = true
+			capturedReq := req
+			captured = &capturedReq
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{"uuid":"inv-uuid"}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	setMetoroAPIEnv(t, server.URL)
+
+	structuredOutput := anomalyInvestigationStructuredOutputFixture()
+
+	_, err := UpdateInvestigationHandler(context.Background(), validUpdateInvestigationArgs(func(args *UpdateInvestigationHandlerArgs) {
+		args.AnomalyInvestigationStructuredOutput = structuredOutput
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if !putCalled {
+		t.Fatalf("expected PUT request to be sent")
+	}
+	if captured == nil {
+		t.Fatalf("expected update payload to be captured")
+	}
+	if !reflect.DeepEqual(captured.AnomalyInvestigationStructuredOutput, structuredOutput) {
+		t.Fatalf("expected structured output to be forwarded unchanged, got %#v", captured.AnomalyInvestigationStructuredOutput)
+	}
+}
+
 func TestUpdateInvestigationHandlerAddsEnvironmentAndNamespaceTags(t *testing.T) {
 	environment := "production"
 	namespace := "payments"


### PR DESCRIPTION
## Summary
- add anomaly investigation structured-output types to the MCP model and request payloads
- forward anomalyInvestigationStructuredOutput through create/update investigation handlers and clarify tool descriptions
- add forwarding tests mirroring the existing deployment verification coverage

## Testing
- go test ./... -count=1