### PR TITLE
Add labels to get_timeseries_data requests

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -512,6 +512,7 @@ type SingleTimeseriesRequest struct {
 	Type              MetricType       `json:"type" jsonschema:"required,enum=metric,enum=trace,enum=logs,enum=kubernetes_resource,description=Type of timeseries data to retrieve. YOU MUST SET THIS TO ONE OF THE AVAILABLE TYPES."`
 	MetricName        string           `json:"metricName" jsonschema:"description=THIS IS ONLY REQUIRED IF THE type is 'metric'.The name of the metric to use for getting the timeseries data for type 'metric'. If metric name ends with _total metoro already accounts for rate differences when returning the value so you don't need to calculate the rate yourself."`
 	Aggregation       Aggregation      `json:"aggregation" jsonschema:"required,enum=sum,enum=count,enum=min,enum=max,enum=avg,enum=p50,enum=p90,enum=p95,enum=p99,description=The aggregation to apply to the timeseries at the datapoint bucket size level. The aggregation will be applied to every datapoint bucket. For example if the bucket size is 1 minute and the aggregation is sum then the sum of all datapoints in a minute will be returned. Do not guess the aggregations. Use the available ones. For traces you can use count p50 p90 p95 p99. for logs its always count. For metrics you can use sum min max avg"`
+	Label             string           `json:"label,omitempty" jsonschema:"description=Optional human-readable label for this timeseries. This only controls chart display names in clients like Guardian and does not affect the query semantics."`
 	JsonPath          *string          `json:"jsonPath" jsonschema:"description=THIS IS ONLY BE SET IF THE type is 'kubernetes_resource' and the aggregate is not count. The json path to use to get the value from the kubernetes resource to plot. for example if this was spec.replicas then the value we return would be aggregate(spec.replicas)"`
 	Filters           []Filter         `json:"filters" jsonschema:"description=Filters to apply to the timeseries. Only the timeseries that match these filters will be returned. You MUST call get_attribute_keys and get_attribute_values tools to get the valid filter keys and values. Example: [{key: 'service.name' values: ['/k8s/namespaceX/serviceX']}]. Do not guess the attribute keys and values."`
 	ExcludeFilters    []Filter         `json:"excludeFilters" jsonschema:"description=Filters to exclude the timeseries data. Timeseries matching the exclude filters will not be returned. You MUST call get_attribute_keys and get_attribute_values tools to get the valid filter keys and values. Example: [{key: 'service.name' values: ['/k8s/namespaceX/serviceX']}]. Do not guess the attribute keys and values"`
@@ -542,6 +543,7 @@ type MetricSpecifier struct {
 
 type Formula struct {
 	Formula string `json:"formula" jsonschema:"description=Math expression combining metric results using their formula identifiers"`
+	Label   string `json:"label,omitempty" jsonschema:"description=Optional human-readable label for this formula result. This only controls chart display names in clients like Guardian and does not affect evaluation semantics."`
 }
 
 type GetMetricAttributesRequest struct {

--- a/tools/get_multi_metric.go
+++ b/tools/get_multi_metric.go
@@ -36,7 +36,7 @@ func GetMultiMetricHandler(ctx context.Context, arguments GetMultiMetricHandlerA
 		StartTime: startTime,
 		EndTime:   endTime,
 		Metrics:   convertTimeseriesToAPITimeseries(arguments.Timeseries, startTime, endTime),
-		Formulas:  arguments.Formulas,
+		Formulas:  sanitizeFormulas(arguments.Formulas),
 	}
 
 	if len(arguments.Timeseries) == 0 {
@@ -56,6 +56,21 @@ func getMultiMetricMetoroCall(ctx context.Context, request model.GetMultiMetricR
 		return nil, fmt.Errorf("error marshaling metric request: %v", err)
 	}
 	return utils.MakeMetoroAPIRequest("POST", "metrics", bytes.NewBuffer(requestBody), utils.GetAPIRequirementsFromRequest(ctx))
+}
+
+func sanitizeFormulas(formulas []model.Formula) []model.Formula {
+	if len(formulas) == 0 {
+		return nil
+	}
+
+	sanitized := make([]model.Formula, len(formulas))
+	for i, formula := range formulas {
+		sanitized[i] = model.Formula{
+			Formula: formula.Formula,
+		}
+	}
+
+	return sanitized
 }
 
 func convertTimeseriesToAPITimeseries(timeseries []model.SingleTimeseriesRequest, startTime int64, endTime int64) []model.SingleMetricRequest {

--- a/tools/get_multi_metric_test.go
+++ b/tools/get_multi_metric_test.go
@@ -1,0 +1,98 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/metoro-io/metoro-mcp-server/model"
+	"github.com/metoro-io/metoro-mcp-server/utils"
+)
+
+func TestGetMultiMetricHandlerAcceptsLabelsWithoutChangingAPIRequest(t *testing.T) {
+	start := "2026-02-19T10:00:00Z"
+	end := "2026-02-19T10:05:00Z"
+
+	var captured model.GetMultiMetricRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/metrics/attributes":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"attributes":[]}`))
+		case "/api/v1/metrics":
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Fatalf("failed to decode metrics request: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"metrics":[]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	setMetoroAPIEnv(t, server.URL)
+
+	_, err := GetMultiMetricHandler(context.Background(), GetMultiMetricHandlerArgs{
+		TimeConfig: utils.TimeConfig{
+			Type:      utils.AbsoluteTimeRange,
+			StartTime: &start,
+			EndTime:   &end,
+		},
+		Timeseries: []model.SingleTimeseriesRequest{
+			{
+				Type:              model.Trace,
+				Aggregation:       model.AggregationCount,
+				BucketSize:        60,
+				FormulaIdentifier: "a",
+				Label:             "Request volume",
+			},
+		},
+		Formulas: []model.Formula{
+			{
+				Formula: "a",
+				Label:   "Displayed formula label",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(captured.Metrics) != 1 {
+		t.Fatalf("expected 1 metric request, got %d", len(captured.Metrics))
+	}
+	if captured.Metrics[0].FormulaIdentifier != "a" {
+		t.Fatalf("expected formula identifier to be preserved, got %q", captured.Metrics[0].FormulaIdentifier)
+	}
+	if len(captured.Formulas) != 1 {
+		t.Fatalf("expected 1 formula, got %d", len(captured.Formulas))
+	}
+	if captured.Formulas[0].Formula != "a" {
+		t.Fatalf("expected formula to be preserved, got %q", captured.Formulas[0].Formula)
+	}
+	if captured.Formulas[0].Label != "" {
+		t.Fatalf("expected formula label to be stripped from downstream API request, got %q", captured.Formulas[0].Label)
+	}
+}
+
+func TestSanitizeFormulasLeavesExistingBehaviorUnchangedWhenLabelsAreOmitted(t *testing.T) {
+	formulas := []model.Formula{
+		{Formula: "a / b"},
+	}
+
+	sanitized := sanitizeFormulas(formulas)
+
+	if len(sanitized) != 1 {
+		t.Fatalf("expected 1 sanitized formula, got %d", len(sanitized))
+	}
+	if sanitized[0].Formula != "a / b" {
+		t.Fatalf("expected formula to be preserved, got %q", sanitized[0].Formula)
+	}
+	if sanitized[0].Label != "" {
+		t.Fatalf("expected omitted label to stay empty, got %q", sanitized[0].Label)
+	}
+}


### PR DESCRIPTION
## Goal
Add presentation-only labels to Guardian's `get_timeseries_data` tool contract so callers can name raw series and formula results.

## Desired behaviour
Guardian can send optional `label` fields on `timeseries[]` and `formulas[]` without changing query execution.
Clients can use those labels for chart legend and tooltip naming instead of falling back to formula identifiers or raw formula text.
Downstream `/api/v1/metrics` requests remain semantically unchanged.

## Implementation
Added optional `label` fields to `model.SingleTimeseriesRequest` and `model.Formula` with schema descriptions that make the display-only intent explicit.
Updated `GetMultiMetricHandler` to sanitize formula labels before constructing the downstream API payload, so only the formula expression is forwarded.
Added targeted Go tests covering labeled requests and the no-label fallback path.
