### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,8 @@ The included token is a demo token, publicly available for anyone to use.
 ## Built with
 
 This server is built on top of our [Golang MCP SDK](https://github.com/metoro-io/mcp-golang).
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/metoro-io-metoro-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/metoro-io-metoro-mcp-server)