### PR TITLE
[codex] Add create alert training mode

### DIFF
--- a/model/model_alert.go
+++ b/model/model_alert.go
@@ -24,6 +24,8 @@ type Alert struct {
 	Metadata   MetadataObject   `json:"metadata"`
 	Type       *AlertType       `json:"type,omitempty"`
 	Timeseries TimeseriesConfig `json:"timeseries"`
+	// Whether the alert should be kept in training mode
+	IsTraining *bool `json:"isTraining,omitempty"`
 }
 
 type _Alert Alert
@@ -127,6 +129,38 @@ func (o *Alert) SetTimeseries(v TimeseriesConfig) {
 	o.Timeseries = v
 }
 
+// GetIsTraining returns the IsTraining field value if set, zero value otherwise.
+func (o *Alert) GetIsTraining() bool {
+	if o == nil || IsNil(o.IsTraining) {
+		var ret bool
+		return ret
+	}
+	return *o.IsTraining
+}
+
+// GetIsTrainingOk returns a tuple with the IsTraining field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Alert) GetIsTrainingOk() (*bool, bool) {
+	if o == nil || IsNil(o.IsTraining) {
+		return nil, false
+	}
+	return o.IsTraining, true
+}
+
+// HasIsTraining returns a boolean if a field has been set.
+func (o *Alert) HasIsTraining() bool {
+	if o != nil && !IsNil(o.IsTraining) {
+		return true
+	}
+
+	return false
+}
+
+// SetIsTraining gets a reference to the given bool and assigns it to the IsTraining field.
+func (o *Alert) SetIsTraining(v bool) {
+	o.IsTraining = &v
+}
+
 func (o Alert) MarshalJSON() ([]byte, error) {
 	toSerialize, err := o.ToMap()
 	if err != nil {
@@ -142,6 +176,9 @@ func (o Alert) ToMap() (map[string]interface{}, error) {
 		toSerialize["type"] = o.Type
 	}
 	toSerialize["timeseries"] = o.Timeseries
+	if !IsNil(o.IsTraining) {
+		toSerialize["isTraining"] = o.IsTraining
+	}
 	return toSerialize, nil
 }
 

--- a/tools/create_alert.go
+++ b/tools/create_alert.go
@@ -22,10 +22,11 @@ type CreateAlertHandlerArgs struct {
 	Threshold         float64                 `json:"threshold" jsonschema:"required,description=The threshold value for the alert. This is the value that will be used together with the the arithmetic condition to see whether the alert should be triggered or not. For example if you set the condition to GreaterThan and the threshold to 100 then the alert will fire if the value of the timeseries is greater than 100."`
 	DatapointsToAlarm int64                   `json:"datapoints_to_alarm" jsonschema:"required,description=The number of datapoints that need to breach the threshold for the alert to be triggered"`
 	EvaluationWindow  int64                   `json:"evaluation_window" jsonschema:"required,description=The evaluation window in number of datapoints. This is the number of datapoints that will be considered for evaluating the alert condition. For example if you set this to then the last 5 datapoints will be considered for evaluating the alert condition. This is useful for smoothing out spikes in the data and preventing false positives."`
+	IsTraining        bool                    `json:"is_training,omitempty" jsonschema:"description=Whether to create the alert in training mode. Training alerts are visible as training and suppress normal alert notifications while in training."`
 }
 
 func CreateAlertHandler(ctx context.Context, arguments CreateAlertHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	alert, err := createAlertFromTimeseries(ctx, arguments.AlertName, arguments.AlertDescription, arguments.Timeseries, arguments.Formula, arguments.Condition, arguments.Threshold, arguments.DatapointsToAlarm, arguments.EvaluationWindow)
+	alert, err := createAlertFromTimeseries(ctx, arguments.AlertName, arguments.AlertDescription, arguments.Timeseries, arguments.Formula, arguments.Condition, arguments.Threshold, arguments.DatapointsToAlarm, arguments.EvaluationWindow, arguments.IsTraining)
 	if err != nil {
 		return nil, fmt.Errorf("error creating alert properties: %v", err)
 	}
@@ -42,7 +43,7 @@ func CreateAlertHandler(ctx context.Context, arguments CreateAlertHandlerArgs) (
 }
 
 // TODO: Implement the conversion logic.
-func createAlertFromTimeseries(ctx context.Context, alertName, alertDescription string, timeseries []model.MetricSpecifier, formula model.Formula, condition string, threshold float64, datapointsToAlarm int64, evaluationWindow int64) (model.Alert, error) {
+func createAlertFromTimeseries(ctx context.Context, alertName, alertDescription string, timeseries []model.MetricSpecifier, formula model.Formula, condition string, threshold float64, datapointsToAlarm int64, evaluationWindow int64, isTraining bool) (model.Alert, error) {
 	// Create dummy time range for the last 10 minutes to validate the timeseries
 	endTime := time.Now().Unix()
 	startTime := endTime - 600 // 10 minutes ago
@@ -127,6 +128,9 @@ func createAlertFromTimeseries(ctx context.Context, alertName, alertDescription 
 				},
 			},
 		},
+	}
+	if isTraining {
+		alert.IsTraining = model.PtrBool(true)
 	}
 
 	return alert, nil

--- a/tools/create_alert_test.go
+++ b/tools/create_alert_test.go
@@ -1,0 +1,95 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/metoro-io/metoro-mcp-server/model"
+)
+
+func TestCreateAlertHandlerSendsIsTrainingOnPublicAlertSchema(t *testing.T) {
+	tests := []struct {
+		name           string
+		isTraining     bool
+		wantField      bool
+		wantIsTraining bool
+	}{
+		{
+			name:           "training enabled",
+			isTraining:     true,
+			wantField:      true,
+			wantIsTraining: true,
+		},
+		{
+			name:           "training omitted by default",
+			isTraining:     false,
+			wantField:      false,
+			wantIsTraining: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured model.CreateUpdateAlertRequest
+			var sawAlertUpdate bool
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/v1/metrics/attributes":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"attributes":[]}`))
+				case "/api/v1/metoroql/convert/metricSpecifierToMetoroql":
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"queries":["count(traces)"]}`))
+				case "/api/v1/alerts/update":
+					sawAlertUpdate = true
+					if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+						t.Fatalf("failed to decode alert request: %v", err)
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(`{"id":"alert-id"}`))
+				default:
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+			}))
+			defer server.Close()
+
+			setMetoroAPIEnv(t, server.URL)
+
+			_, err := CreateAlertHandler(context.Background(), CreateAlertHandlerArgs{
+				AlertName:        "High latency",
+				AlertDescription: "Latency is above threshold",
+				Timeseries: []model.MetricSpecifier{
+					{
+						MetricType:        model.Trace,
+						Aggregation:       model.AggregationCount,
+						BucketSize:        60,
+						FormulaIdentifier: "a",
+					},
+				},
+				Formula:           model.Formula{Formula: "a"},
+				Condition:         "GreaterThan",
+				Threshold:         10,
+				DatapointsToAlarm: 3,
+				EvaluationWindow:  5,
+				IsTraining:        tt.isTraining,
+			})
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			if !sawAlertUpdate {
+				t.Fatalf("expected create_alert to call /api/v1/alerts/update")
+			}
+			if captured.Alert.HasIsTraining() != tt.wantField {
+				t.Fatalf("expected isTraining field presence %v, got %v", tt.wantField, captured.Alert.HasIsTraining())
+			}
+			if captured.Alert.GetIsTraining() != tt.wantIsTraining {
+				t.Fatalf("expected isTraining %v, got %v", tt.wantIsTraining, captured.Alert.GetIsTraining())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Goal

Add support for creating alerts in training mode through the MCP `create_alert` tool while continuing to use the public Metoro alert API.

## Desired Behaviour

Callers can pass `is_training: true` to `create_alert`. When set, the tool includes `alert.isTraining: true` in the existing `/api/v1/alerts/update` request. Existing calls that omit `is_training` keep the previous request body shape and do not send the field.

## Implementation

- Added optional `is_training` to `CreateAlertHandlerArgs`.
- Added optional `isTraining` support to the public alert model used by the MCP server.
- Threaded the flag through alert construction without changing the endpoint.
- Added coverage for both the training-enabled and default cases.

## Testing

- `go test ./...`