### PR TITLE
Add AI investigation flag to create alert tool

### DIFF
--- a/model/model_alert.go
+++ b/model/model_alert.go
@@ -21,9 +21,11 @@ var _ MappedNullable = &Alert{}
 
 // Alert struct for Alert
 type Alert struct {
-	Metadata   MetadataObject   `json:"metadata"`
-	Type       *AlertType       `json:"type,omitempty"`
-	Timeseries TimeseriesConfig `json:"timeseries"`
+	Metadata MetadataObject `json:"metadata"`
+	Type     *AlertType     `json:"type,omitempty"`
+	// Whether Metoro should automatically start an AI investigation when this alert fires.
+	InvestigateOnFire *bool            `json:"investigateOnFire,omitempty"`
+	Timeseries        TimeseriesConfig `json:"timeseries"`
 }
 
 type _Alert Alert
@@ -103,6 +105,38 @@ func (o *Alert) SetType(v AlertType) {
 	o.Type = &v
 }
 
+// GetInvestigateOnFire returns the InvestigateOnFire field value if set, zero value otherwise.
+func (o *Alert) GetInvestigateOnFire() bool {
+	if o == nil || IsNil(o.InvestigateOnFire) {
+		var ret bool
+		return ret
+	}
+	return *o.InvestigateOnFire
+}
+
+// GetInvestigateOnFireOk returns a tuple with the InvestigateOnFire field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Alert) GetInvestigateOnFireOk() (*bool, bool) {
+	if o == nil || IsNil(o.InvestigateOnFire) {
+		return nil, false
+	}
+	return o.InvestigateOnFire, true
+}
+
+// HasInvestigateOnFire returns a boolean if a field has been set.
+func (o *Alert) HasInvestigateOnFire() bool {
+	if o != nil && !IsNil(o.InvestigateOnFire) {
+		return true
+	}
+
+	return false
+}
+
+// SetInvestigateOnFire gets a reference to the given bool and assigns it to the InvestigateOnFire field.
+func (o *Alert) SetInvestigateOnFire(v bool) {
+	o.InvestigateOnFire = &v
+}
+
 // GetTimeseries returns the Timeseries field value
 func (o *Alert) GetTimeseries() TimeseriesConfig {
 	if o == nil {
@@ -140,6 +174,9 @@ func (o Alert) ToMap() (map[string]interface{}, error) {
 	toSerialize["metadata"] = o.Metadata
 	if !IsNil(o.Type) {
 		toSerialize["type"] = o.Type
+	}
+	if !IsNil(o.InvestigateOnFire) {
+		toSerialize["investigateOnFire"] = o.InvestigateOnFire
 	}
 	toSerialize["timeseries"] = o.Timeseries
 	return toSerialize, nil

--- a/tools/create_alert.go
+++ b/tools/create_alert.go
@@ -22,10 +22,11 @@ type CreateAlertHandlerArgs struct {
 	Threshold         float64                 `json:"threshold" jsonschema:"required,description=The threshold value for the alert. This is the value that will be used together with the the arithmetic condition to see whether the alert should be triggered or not. For example if you set the condition to GreaterThan and the threshold to 100 then the alert will fire if the value of the timeseries is greater than 100."`
 	DatapointsToAlarm int64                   `json:"datapoints_to_alarm" jsonschema:"required,description=The number of datapoints that need to breach the threshold for the alert to be triggered"`
 	EvaluationWindow  int64                   `json:"evaluation_window" jsonschema:"required,description=The evaluation window in number of datapoints. This is the number of datapoints that will be considered for evaluating the alert condition. For example if you set this to then the last 5 datapoints will be considered for evaluating the alert condition. This is useful for smoothing out spikes in the data and preventing false positives."`
+	InvestigateOnFire bool                    `json:"investigate_on_fire" jsonschema:"description=Whether Metoro should automatically start an AI investigation when this alert fires. Defaults to false."`
 }
 
 func CreateAlertHandler(ctx context.Context, arguments CreateAlertHandlerArgs) (*mcpgolang.ToolResponse, error) {
-	alert, err := createAlertFromTimeseries(ctx, arguments.AlertName, arguments.AlertDescription, arguments.Timeseries, arguments.Formula, arguments.Condition, arguments.Threshold, arguments.DatapointsToAlarm, arguments.EvaluationWindow)
+	alert, err := createAlertFromTimeseries(ctx, arguments.AlertName, arguments.AlertDescription, arguments.Timeseries, arguments.Formula, arguments.Condition, arguments.Threshold, arguments.DatapointsToAlarm, arguments.EvaluationWindow, arguments.InvestigateOnFire)
 	if err != nil {
 		return nil, fmt.Errorf("error creating alert properties: %v", err)
 	}
@@ -42,7 +43,7 @@ func CreateAlertHandler(ctx context.Context, arguments CreateAlertHandlerArgs) (
 }
 
 // TODO: Implement the conversion logic.
-func createAlertFromTimeseries(ctx context.Context, alertName, alertDescription string, timeseries []model.MetricSpecifier, formula model.Formula, condition string, threshold float64, datapointsToAlarm int64, evaluationWindow int64) (model.Alert, error) {
+func createAlertFromTimeseries(ctx context.Context, alertName, alertDescription string, timeseries []model.MetricSpecifier, formula model.Formula, condition string, threshold float64, datapointsToAlarm int64, evaluationWindow int64, investigateOnFire bool) (model.Alert, error) {
 	// Create dummy time range for the last 10 minutes to validate the timeseries
 	endTime := time.Now().Unix()
 	startTime := endTime - 600 // 10 minutes ago
@@ -127,6 +128,9 @@ func createAlertFromTimeseries(ctx context.Context, alertName, alertDescription 
 				},
 			},
 		},
+	}
+	if investigateOnFire {
+		alert.SetInvestigateOnFire(true)
 	}
 
 	return alert, nil

--- a/tools/create_alert_test.go
+++ b/tools/create_alert_test.go
@@ -1,0 +1,84 @@
+package tools
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/metoro-io/metoro-mcp-server/model"
+)
+
+func TestCreateAlertHandlerArgsUnmarshalsInvestigateOnFire(t *testing.T) {
+	var args CreateAlertHandlerArgs
+	if err := json.Unmarshal([]byte(`{"investigate_on_fire":true}`), &args); err != nil {
+		t.Fatalf("failed to unmarshal args: %v", err)
+	}
+
+	if !args.InvestigateOnFire {
+		t.Fatal("expected investigate_on_fire to unmarshal to true")
+	}
+}
+
+func TestCreateAlertPayloadUsesTopLevelInvestigateOnFire(t *testing.T) {
+	alert := model.Alert{
+		Metadata: model.MetadataObject{
+			Name: "High 5XX Rate",
+			Id:   "high-5xx-rate",
+		},
+		Timeseries: model.TimeseriesConfig{},
+	}
+	alert.SetInvestigateOnFire(true)
+
+	request := model.CreateUpdateAlertRequest{Alert: alert}
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(requestJSON, &payload); err != nil {
+		t.Fatalf("failed to unmarshal request JSON: %v", err)
+	}
+	alertPayload, ok := payload["alert"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected alert payload object, got %T", payload["alert"])
+	}
+
+	if got := alertPayload["investigateOnFire"]; got != true {
+		t.Fatalf("expected top-level alert.investigateOnFire=true, got %#v", got)
+	}
+	if metadataPayload, ok := alertPayload["metadata"].(map[string]any); ok {
+		if _, exists := metadataPayload["investigateOnFire"]; exists {
+			t.Fatal("did not expect investigateOnFire under alert.metadata")
+		}
+	}
+	if timeseriesPayload, ok := alertPayload["timeseries"].(map[string]any); ok {
+		if _, exists := timeseriesPayload["investigateOnFire"]; exists {
+			t.Fatal("did not expect investigateOnFire under alert.timeseries")
+		}
+	}
+}
+
+func TestNewAlertOmitsInvestigateOnFireByDefault(t *testing.T) {
+	alert := model.NewAlert(model.MetadataObject{
+		Name: "High 5XX Rate",
+		Id:   "high-5xx-rate",
+	}, model.TimeseriesConfig{})
+
+	request := model.CreateUpdateAlertRequest{Alert: *alert}
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(requestJSON, &payload); err != nil {
+		t.Fatalf("failed to unmarshal request JSON: %v", err)
+	}
+	alertPayload, ok := payload["alert"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected alert payload object, got %T", payload["alert"])
+	}
+	if _, exists := alertPayload["investigateOnFire"]; exists {
+		t.Fatal("did not expect investigateOnFire to be marshaled by default")
+	}
+}


### PR DESCRIPTION
## High level goal
Let the MCP `create_alert` tool opt alerts into Metoro AI investigations when those alerts fire.

## Desired behaviour
Callers can pass `investigate_on_fire: true` to `create_alert`. The tool serializes this as top-level `alert.investigateOnFire: true` in the public alert payload sent to Metoro.

## Specifics
- Added `investigate_on_fire` to the `CreateAlertHandlerArgs` MCP schema.
- Added `InvestigateOnFire` support to the generated-style alert model so payloads marshal as `investigateOnFire`.
- Threaded the option through `createAlertFromTimeseries` and only set the payload field when requested.
- Added tests for argument decoding and top-level alert payload placement.

Tests:
- `go test ./tools`
- `git diff --check`
