### PR TITLE
[codex] fit oversized log responses

### DIFF
--- a/tools/log_response_guard.go
+++ b/tools/log_response_guard.go
@@ -3,7 +3,9 @@ package tools
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
+	"unicode/utf8"
 
 	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
@@ -14,6 +16,7 @@ const (
 	logAttributeValueLengthLimit = 600
 	stackTraceValueLengthLimit   = 300
 	truncatedValueSuffix         = "... [truncated]"
+	minDynamicLogFieldLength     = len(truncatedValueSuffix)
 )
 
 var strictLogAttributeKeys = map[string]struct{}{
@@ -22,7 +25,168 @@ var strictLogAttributeKeys = map[string]struct{}{
 	"error":        {},
 }
 
-var LogsToolResponseGuard = NewToolResponseGuard(trimLargeLogFieldsInToolResponse, ToolResponseGuardOptions{})
+var LogsToolResponseGuard = NewLogsToolResponseGuard(ToolResponseGuardOptions{})
+
+func NewLogsToolResponseGuard(options ToolResponseGuardOptions) ToolResponseGuard {
+	return func(toolName string, response *mcpgolang.ToolResponse) (*mcpgolang.ToolResponse, error) {
+		if response == nil {
+			return nil, nil
+		}
+
+		maxTokens := resolveToolResponseMaxTokens(options)
+		guardedResponse, err := trimAndFitLogsToolResponse(response, maxTokens)
+		if err != nil {
+			return nil, err
+		}
+
+		tokenCount, err := estimateToolResponseTokens(guardedResponse)
+		if err != nil {
+			return nil, fmt.Errorf("failed to estimate response token size for tool %q: %w", toolName, err)
+		}
+
+		if tokenCount > maxTokens {
+			return nil, fmt.Errorf(resolveToolResponseTooLargeMessage(options))
+		}
+
+		return guardedResponse, nil
+	}
+}
+
+func trimAndFitLogsToolResponse(response *mcpgolang.ToolResponse, maxTokens int) (*mcpgolang.ToolResponse, error) {
+	trimmedResponse, err := trimLargeLogFieldsInToolResponse("", response)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenCount, err := estimateToolResponseTokens(trimmedResponse)
+	if err != nil {
+		return nil, err
+	}
+	if tokenCount <= maxTokens {
+		return trimmedResponse, nil
+	}
+
+	for _, content := range trimmedResponse.Content {
+		if content == nil || content.Type != mcpgolang.ContentTypeText || content.TextContent == nil {
+			continue
+		}
+
+		err := fitLogsContentToToolResponseBudget(content, trimmedResponse, maxTokens)
+		if err != nil {
+			return nil, err
+		}
+
+		tokenCount, err = estimateToolResponseTokens(trimmedResponse)
+		if err != nil {
+			return nil, err
+		}
+		if tokenCount <= maxTokens {
+			return trimmedResponse, nil
+		}
+	}
+
+	return trimmedResponse, nil
+}
+
+func fitLogsContentToToolResponseBudget(content *mcpgolang.Content, response *mcpgolang.ToolResponse, maxTokens int) error {
+	logsResponse, ok := parseLogsPayloadText(content.TextContent.Text)
+	if !ok {
+		return nil
+	}
+
+	if err := setLogsContentText(content, logsResponse); err != nil {
+		return err
+	}
+
+	for {
+		tokenCount, err := estimateToolResponseTokens(response)
+		if err != nil {
+			return err
+		}
+		if tokenCount <= maxTokens {
+			return nil
+		}
+
+		field := findLongestShrinkableLogField(&logsResponse)
+		if field == nil {
+			return nil
+		}
+
+		nextLimit := utf8.RuneCountInString(field.value) / 2
+		if nextLimit < minDynamicLogFieldLength {
+			nextLimit = minDynamicLogFieldLength
+		}
+
+		truncated, wasTruncated := truncateWithSuffix(field.value, nextLimit)
+		if !wasTruncated {
+			return nil
+		}
+
+		field.set(truncated)
+		if err := setLogsContentText(content, logsResponse); err != nil {
+			return err
+		}
+	}
+}
+
+func setLogsContentText(content *mcpgolang.Content, logsResponse model.GetLogsResponse) error {
+	serialized, err := json.Marshal(logsResponse)
+	if err != nil {
+		return fmt.Errorf("failed to marshal trimmed logs response: %w", err)
+	}
+	content.TextContent.Text = string(serialized)
+	return nil
+}
+
+type logStringFieldRef struct {
+	value string
+	set   func(string)
+}
+
+func findLongestShrinkableLogField(logsResponse *model.GetLogsResponse) *logStringFieldRef {
+	var result *logStringFieldRef
+	var resultLength int
+
+	consider := func(value string, set func(string)) {
+		valueLength := utf8.RuneCountInString(value)
+		if valueLength <= minDynamicLogFieldLength || valueLength <= resultLength {
+			return
+		}
+
+		result = &logStringFieldRef{
+			value: value,
+			set:   set,
+		}
+		resultLength = valueLength
+	}
+
+	for i := range logsResponse.Logs {
+		logIndex := i
+		consider(logsResponse.Logs[logIndex].Message, func(value string) {
+			logsResponse.Logs[logIndex].Message = value
+		})
+
+		considerLogAttributeFields(logsResponse.Logs[logIndex].LogAttributes, consider)
+		considerLogAttributeFields(logsResponse.Logs[logIndex].ResourceAttributes, consider)
+	}
+
+	return result
+}
+
+func considerLogAttributeFields(attributes map[string]string, consider func(string, func(string))) {
+	keys := make([]string, 0, len(attributes))
+	for key := range attributes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		attributeKey := key
+		consider(attributes[attributeKey], func(value string) {
+			attributes[attributeKey] = value
+		})
+	}
+}
 
 func trimLargeLogFieldsInToolResponse(_ string, response *mcpgolang.ToolResponse) (*mcpgolang.ToolResponse, error) {
 	for _, content := range response.Content {
@@ -43,9 +207,8 @@ func trimLargeLogFieldsInToolResponse(_ string, response *mcpgolang.ToolResponse
 }
 
 func trimLogsPayloadText(raw string) (string, bool, error) {
-	var logsResponse model.GetLogsResponse
-	if err := json.Unmarshal([]byte(raw), &logsResponse); err != nil {
-		// Not all tools with this guard necessarily return log payloads all the time.
+	logsResponse, ok := parseLogsPayloadText(raw)
+	if !ok {
 		return raw, false, nil
 	}
 
@@ -60,6 +223,23 @@ func trimLogsPayloadText(raw string) (string, bool, error) {
 	}
 
 	return string(serialized), true, nil
+}
+
+func parseLogsPayloadText(raw string) (model.GetLogsResponse, bool) {
+	var rawObject map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &rawObject); err != nil {
+		return model.GetLogsResponse{}, false
+	}
+	if _, ok := rawObject["logs"]; !ok {
+		return model.GetLogsResponse{}, false
+	}
+
+	var logsResponse model.GetLogsResponse
+	if err := json.Unmarshal([]byte(raw), &logsResponse); err != nil {
+		return model.GetLogsResponse{}, false
+	}
+
+	return logsResponse, true
 }
 
 func trimLogsModelResponse(logsResponse *model.GetLogsResponse) bool {

--- a/tools/log_response_guard.go
+++ b/tools/log_response_guard.go
@@ -89,12 +89,12 @@ func trimAndFitLogsToolResponse(response *mcpgolang.ToolResponse, maxTokens int)
 }
 
 func fitLogsContentToToolResponseBudget(content *mcpgolang.Content, response *mcpgolang.ToolResponse, maxTokens int) error {
-	logsResponse, ok := parseLogsPayloadText(content.TextContent.Text)
+	logsPayload, ok := parseLogsPayloadText(content.TextContent.Text)
 	if !ok {
 		return nil
 	}
 
-	if err := setLogsContentText(content, logsResponse); err != nil {
+	if err := setLogsContentText(content, logsPayload); err != nil {
 		return err
 	}
 
@@ -107,7 +107,7 @@ func fitLogsContentToToolResponseBudget(content *mcpgolang.Content, response *mc
 			return nil
 		}
 
-		field := findLongestShrinkableLogField(&logsResponse)
+		field := findLongestShrinkableLogField(&logsPayload.logsResponse)
 		if field == nil {
 			return nil
 		}
@@ -123,14 +123,14 @@ func fitLogsContentToToolResponseBudget(content *mcpgolang.Content, response *mc
 		}
 
 		field.set(truncated)
-		if err := setLogsContentText(content, logsResponse); err != nil {
+		if err := setLogsContentText(content, logsPayload); err != nil {
 			return err
 		}
 	}
 }
 
-func setLogsContentText(content *mcpgolang.Content, logsResponse model.GetLogsResponse) error {
-	serialized, err := json.Marshal(logsResponse)
+func setLogsContentText(content *mcpgolang.Content, logsPayload *logsPayloadText) error {
+	serialized, err := logsPayload.marshal()
 	if err != nil {
 		return fmt.Errorf("failed to marshal trimmed logs response: %w", err)
 	}
@@ -207,17 +207,17 @@ func trimLargeLogFieldsInToolResponse(_ string, response *mcpgolang.ToolResponse
 }
 
 func trimLogsPayloadText(raw string) (string, bool, error) {
-	logsResponse, ok := parseLogsPayloadText(raw)
+	logsPayload, ok := parseLogsPayloadText(raw)
 	if !ok {
 		return raw, false, nil
 	}
 
-	changed := trimLogsModelResponse(&logsResponse)
+	changed := trimLogsModelResponse(&logsPayload.logsResponse)
 	if !changed {
 		return raw, false, nil
 	}
 
-	serialized, err := json.Marshal(logsResponse)
+	serialized, err := logsPayload.marshal()
 	if err != nil {
 		return "", false, fmt.Errorf("failed to marshal trimmed logs response: %w", err)
 	}
@@ -225,21 +225,48 @@ func trimLogsPayloadText(raw string) (string, bool, error) {
 	return string(serialized), true, nil
 }
 
-func parseLogsPayloadText(raw string) (model.GetLogsResponse, bool) {
+type logsPayloadText struct {
+	rawObject    map[string]json.RawMessage
+	logsResponse model.GetLogsResponse
+}
+
+func (payload *logsPayloadText) marshal() (string, error) {
+	logs, err := json.Marshal(payload.logsResponse.Logs)
+	if err != nil {
+		return "", err
+	}
+
+	payload.rawObject["logs"] = logs
+
+	serialized, err := json.Marshal(payload.rawObject)
+	if err != nil {
+		return "", err
+	}
+
+	return string(serialized), nil
+}
+
+func parseLogsPayloadText(raw string) (*logsPayloadText, bool) {
 	var rawObject map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(raw), &rawObject); err != nil {
-		return model.GetLogsResponse{}, false
+		return nil, false
 	}
-	if _, ok := rawObject["logs"]; !ok {
-		return model.GetLogsResponse{}, false
-	}
-
-	var logsResponse model.GetLogsResponse
-	if err := json.Unmarshal([]byte(raw), &logsResponse); err != nil {
-		return model.GetLogsResponse{}, false
+	rawLogs, ok := rawObject["logs"]
+	if !ok {
+		return nil, false
 	}
 
-	return logsResponse, true
+	var logs []model.Log
+	if err := json.Unmarshal(rawLogs, &logs); err != nil {
+		return nil, false
+	}
+
+	return &logsPayloadText{
+		rawObject: rawObject,
+		logsResponse: model.GetLogsResponse{
+			Logs: logs,
+		},
+	}, true
 }
 
 func trimLogsModelResponse(logsResponse *model.GetLogsResponse) bool {

--- a/tools/log_response_guard_test.go
+++ b/tools/log_response_guard_test.go
@@ -119,6 +119,65 @@ func TestTrimLogsPayloadTextLeavesNonLogPayloadUnchanged(t *testing.T) {
 	}
 }
 
+func TestTrimLogsPayloadTextPreservesTopLevelFields(t *testing.T) {
+	rawPayload := map[string]any{
+		"logs": []model.Log{
+			{
+				Message: strings.Repeat("m", logMessageLengthLimit+1),
+			},
+		},
+		"cursor": "next-page",
+		"metadata": map[string]any{
+			"source": "context",
+		},
+	}
+
+	raw, err := json.Marshal(rawPayload)
+	if err != nil {
+		t.Fatalf("failed to marshal test response: %v", err)
+	}
+
+	trimmed, changed, err := trimLogsPayloadText(string(raw))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected payload to be changed")
+	}
+
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		t.Fatalf("failed to unmarshal trimmed payload: %v", err)
+	}
+
+	var cursor string
+	if err := json.Unmarshal(parsed["cursor"], &cursor); err != nil {
+		t.Fatalf("failed to unmarshal cursor: %v", err)
+	}
+	if cursor != "next-page" {
+		t.Fatalf("expected cursor to be preserved, got %q", cursor)
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal(parsed["metadata"], &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+	if metadata["source"] != "context" {
+		t.Fatalf("expected metadata source to be preserved, got %q", metadata["source"])
+	}
+
+	var logs []model.Log
+	if err := json.Unmarshal(parsed["logs"], &logs); err != nil {
+		t.Fatalf("failed to unmarshal logs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected one log, got %d", len(logs))
+	}
+	if !strings.HasSuffix(logs[0].Message, truncatedValueSuffix) {
+		t.Fatalf("expected log message to include truncation suffix")
+	}
+}
+
 func TestLogsToolResponseGuardFitsOversizedLogsWithDynamicTruncation(t *testing.T) {
 	const maxTokens = 900
 
@@ -142,7 +201,14 @@ func TestLogsToolResponseGuardFitsOversizedLogsWithDynamicTruncation(t *testing.
 		}
 	}
 
-	raw, err := json.Marshal(logsResponse)
+	rawPayload := map[string]any{
+		"logs":   logsResponse.Logs,
+		"cursor": "next-page",
+		"metadata": map[string]any{
+			"source": "context",
+		},
+	}
+	raw, err := json.Marshal(rawPayload)
 	if err != nil {
 		t.Fatalf("failed to marshal test response: %v", err)
 	}
@@ -176,16 +242,37 @@ func TestLogsToolResponseGuardFitsOversizedLogsWithDynamicTruncation(t *testing.
 		t.Fatalf("expected guarded response to fit under %d tokens, got %d", maxTokens, tokenCount)
 	}
 
-	var parsed model.GetLogsResponse
+	var parsed map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(guarded.Content[0].TextContent.Text), &parsed); err != nil {
 		t.Fatalf("failed to unmarshal guarded payload: %v", err)
 	}
-	if len(parsed.Logs) != len(logsResponse.Logs) {
-		t.Fatalf("expected %d logs to be preserved, got %d", len(logsResponse.Logs), len(parsed.Logs))
+
+	var cursor string
+	if err := json.Unmarshal(parsed["cursor"], &cursor); err != nil {
+		t.Fatalf("failed to unmarshal cursor: %v", err)
+	}
+	if cursor != "next-page" {
+		t.Fatalf("expected cursor to be preserved, got %q", cursor)
+	}
+
+	var metadata map[string]string
+	if err := json.Unmarshal(parsed["metadata"], &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata: %v", err)
+	}
+	if metadata["source"] != "context" {
+		t.Fatalf("expected metadata source to be preserved, got %q", metadata["source"])
+	}
+
+	var parsedLogs []model.Log
+	if err := json.Unmarshal(parsed["logs"], &parsedLogs); err != nil {
+		t.Fatalf("failed to unmarshal logs: %v", err)
+	}
+	if len(parsedLogs) != len(logsResponse.Logs) {
+		t.Fatalf("expected %d logs to be preserved, got %d", len(logsResponse.Logs), len(parsedLogs))
 	}
 
 	dynamicallyTrimmedMessage := false
-	for _, log := range parsed.Logs {
+	for _, log := range parsedLogs {
 		if !strings.HasSuffix(log.Message, truncatedValueSuffix) {
 			t.Fatalf("expected dynamically fitted log message to include truncation suffix")
 		}

--- a/tools/log_response_guard_test.go
+++ b/tools/log_response_guard_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	mcpgolang "github.com/metoro-io/mcp-golang"
 	"github.com/metoro-io/metoro-mcp-server/model"
 )
 
@@ -115,5 +116,115 @@ func TestTrimLogsPayloadTextLeavesNonLogPayloadUnchanged(t *testing.T) {
 	}
 	if trimmed != raw {
 		t.Fatalf("expected payload to remain unchanged")
+	}
+}
+
+func TestLogsToolResponseGuardFitsOversizedLogsWithDynamicTruncation(t *testing.T) {
+	const maxTokens = 900
+
+	logsResponse := model.GetLogsResponse{
+		Logs: make([]model.Log, 5),
+	}
+	for i := range logsResponse.Logs {
+		logsResponse.Logs[i] = model.Log{
+			Time:     1700000000000 + int64(i),
+			Severity: "ERROR",
+			Message:  strings.Repeat("message", logMessageLengthLimit),
+			LogAttributes: map[string]string{
+				"payload":    strings.Repeat("payload", logAttributeValueLengthLimit),
+				"stacktrace": strings.Repeat("stacktrace", stackTraceValueLengthLimit),
+			},
+			ResourceAttributes: map[string]string{
+				"k8s.pod": strings.Repeat("resource", logAttributeValueLengthLimit),
+			},
+			ServiceName: "checkout",
+			Environment: "production",
+		}
+	}
+
+	raw, err := json.Marshal(logsResponse)
+	if err != nil {
+		t.Fatalf("failed to marshal test response: %v", err)
+	}
+
+	staticOnlyResponse := mcpgolang.NewToolResponse(mcpgolang.NewTextContent(string(raw)))
+	if _, err := trimLargeLogFieldsInToolResponse("get_logs", staticOnlyResponse); err != nil {
+		t.Fatalf("expected static trim to succeed: %v", err)
+	}
+	staticTokenCount, err := estimateToolResponseTokens(staticOnlyResponse)
+	if err != nil {
+		t.Fatalf("expected token estimate to succeed: %v", err)
+	}
+	if staticTokenCount <= maxTokens {
+		t.Fatalf("test fixture should still be too large after static trimming; got %d tokens", staticTokenCount)
+	}
+
+	guard := NewLogsToolResponseGuard(ToolResponseGuardOptions{MaxTokens: maxTokens})
+	guarded, err := guard("get_logs", mcpgolang.NewToolResponse(mcpgolang.NewTextContent(string(raw))))
+	if err != nil {
+		t.Fatalf("expected guard to fit oversized logs, got %v", err)
+	}
+	if guarded == nil {
+		t.Fatalf("expected guarded response")
+	}
+
+	tokenCount, err := estimateToolResponseTokens(guarded)
+	if err != nil {
+		t.Fatalf("expected token estimate to succeed: %v", err)
+	}
+	if tokenCount > maxTokens {
+		t.Fatalf("expected guarded response to fit under %d tokens, got %d", maxTokens, tokenCount)
+	}
+
+	var parsed model.GetLogsResponse
+	if err := json.Unmarshal([]byte(guarded.Content[0].TextContent.Text), &parsed); err != nil {
+		t.Fatalf("failed to unmarshal guarded payload: %v", err)
+	}
+	if len(parsed.Logs) != len(logsResponse.Logs) {
+		t.Fatalf("expected %d logs to be preserved, got %d", len(logsResponse.Logs), len(parsed.Logs))
+	}
+
+	dynamicallyTrimmedMessage := false
+	for _, log := range parsed.Logs {
+		if !strings.HasSuffix(log.Message, truncatedValueSuffix) {
+			t.Fatalf("expected dynamically fitted log message to include truncation suffix")
+		}
+		if utf8.RuneCountInString(log.Message) < logMessageLengthLimit {
+			dynamicallyTrimmedMessage = true
+		}
+
+		for key, value := range log.LogAttributes {
+			if !strings.HasSuffix(value, truncatedValueSuffix) {
+				t.Fatalf("expected log attribute %s to include truncation suffix", key)
+			}
+		}
+		for key, value := range log.ResourceAttributes {
+			if !strings.HasSuffix(value, truncatedValueSuffix) {
+				t.Fatalf("expected resource attribute %s to include truncation suffix", key)
+			}
+		}
+	}
+	if !dynamicallyTrimmedMessage {
+		t.Fatalf("expected at least one message to be trimmed below the static limit")
+	}
+}
+
+func TestLogsToolResponseGuardReturnsTooLargeForOversizedNonLogPayload(t *testing.T) {
+	raw := `{"foo":"` + strings.Repeat("x", 4000) + `"}`
+	response := mcpgolang.NewToolResponse(mcpgolang.NewTextContent(raw))
+
+	guard := NewLogsToolResponseGuard(ToolResponseGuardOptions{MaxTokens: 50})
+	guarded, err := guard("get_logs", response)
+	if err == nil {
+		t.Fatalf("expected oversized non-log payload to fail")
+	}
+	if err.Error() != toolResponseTooLargeErrorMessage {
+		t.Fatalf("expected %q, got %q", toolResponseTooLargeErrorMessage, err.Error())
+	}
+	if guarded != nil {
+		t.Fatalf("expected nil response when guard fails")
+	}
+	if response.Content[0].TextContent.Text != raw {
+		t.Fatalf("expected non-log payload to remain unchanged")
 	}
 }

--- a/tools/response_guard.go
+++ b/tools/response_guard.go
@@ -52,15 +52,8 @@ func NewToolResponseGuard(modifier ToolResponseModifier, options ToolResponseGua
 			}
 		}
 
-		maxTokens := options.MaxTokens
-		if maxTokens <= 0 {
-			maxTokens = getGlobalToolResponseMaxTokens()
-		}
-
-		tooLargeMessage := options.TooLargeErrorMessage
-		if tooLargeMessage == "" {
-			tooLargeMessage = toolResponseTooLargeErrorMessage
-		}
+		maxTokens := resolveToolResponseMaxTokens(options)
+		tooLargeMessage := resolveToolResponseTooLargeMessage(options)
 
 		tokenCount, err := estimateToolResponseTokens(guardedResponse)
 		if err != nil {
@@ -73,6 +66,22 @@ func NewToolResponseGuard(modifier ToolResponseModifier, options ToolResponseGua
 
 		return guardedResponse, nil
 	}
+}
+
+func resolveToolResponseMaxTokens(options ToolResponseGuardOptions) int {
+	if options.MaxTokens > 0 {
+		return options.MaxTokens
+	}
+
+	return getGlobalToolResponseMaxTokens()
+}
+
+func resolveToolResponseTooLargeMessage(options ToolResponseGuardOptions) string {
+	if options.TooLargeErrorMessage != "" {
+		return options.TooLargeErrorMessage
+	}
+
+	return toolResponseTooLargeErrorMessage
 }
 
 func getGlobalToolResponseMaxTokens() int {


### PR DESCRIPTION
## What changed
- Added a log-specific response guard that dynamically truncates long log message and attribute fields until the full MCP tool response fits the configured token budget.
- Kept the generic response guard behavior unchanged for non-log tools.
- Added regression tests for oversized log responses and oversized non-log payload fallback behavior.

## Why
`get_logs` already statically trimmed very long log fields, but the generic response guard could still reject the whole response when the trimmed payload remained over the token limit. That meant callers got no logs back. This change keeps the log entries and continues shrinking long fields before falling back to the existing too-large error.

## Validation
- `go test ./...`
